### PR TITLE
Introduce RingBuf PerfDataSources

### DIFF
--- a/one_collect/Cargo.toml
+++ b/one_collect/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+syscalls = { version = "0.6.13", features = ["x86_64", "arm"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/one_collect/src/perf_event/abi.rs
+++ b/one_collect/src/perf_event/abi.rs
@@ -1,6 +1,7 @@
 use std::array::TryFromSliceError;
 
 // Current possible sample layout:
+// u64    id;          /* if PERF_SAMPLE_IDENTIFIER */
 // u64    ip;          /* if PERF_SAMPLE_IP */
 // u32    pid, tid;    /* if PERF_SAMPLE_TID */
 // u64    time;        /* if PERF_SAMPLE_TIME */
@@ -49,9 +50,11 @@ pub const PERF_SAMPLE_REGS_USER: u64 = 1 << 12;
 pub const PERF_SAMPLE_STACK_USER: u64 = 1 << 13;
 pub const PERF_SAMPLE_WEIGHT: u64 = 1 << 14;
 pub const PERF_SAMPLE_DATA_SRC: u64 = 1 << 15;
+pub const PERF_SAMPLE_IDENTIFIER: u64 = 1 << 16;
 pub const PERF_SAMPLE_TRANSACTION: u64 = 1 << 17;
 pub const PERF_SAMPLE_REGS_INTR: u64 = 1 << 18;
 pub const PERF_SAMPLE_PHYS_ADDR: u64 = 1 << 19;
+pub const PERF_SAMPLE_AUX: u64 = 1 << 20;
 pub const PERF_SAMPLE_CGROUP: u64 = 1 << 21;
 
 // Supported record types (header.entry_type)

--- a/one_collect/src/perf_event/rb/mod.rs
+++ b/one_collect/src/perf_event/rb/mod.rs
@@ -1,0 +1,1017 @@
+use std::marker::PhantomData;
+use std::arch::asm;
+use std::rc::Rc;
+
+use super::abi;
+use super::*;
+
+pub mod source;
+
+/* Arch: X64 */
+#[cfg(target_arch = "x86_64")]
+unsafe fn rmb() {
+    asm!("lfence");
+}
+
+#[cfg(target_arch = "x86_64")]
+unsafe fn mb() {
+    asm!("mfence");
+}
+
+/* Arch: ARM64 */
+#[cfg(target_arch = "aarch64")]
+unsafe fn rmb() {
+    asm!("dsb ld");
+}
+
+#[cfg(target_arch = "aarch64")]
+unsafe fn mb() {
+    asm!("dsb sy");
+}
+
+/* All Archs */
+const FLAG_DISABLED: u64 = 1 << 0;
+const _FLAG_INHERIT: u64 = 1 << 1;
+const _FLAG_PINNED: u64 = 1 << 2;
+const _FLAG_EXCLUSIVE: u64 = 1 << 3;
+const _FLAG_EXCLUDE_USER: u64 = 1 << 4;
+const _FLAG_EXCLUDE_KERNEL: u64 = 1 << 5;
+const FLAG_EXCLUDE_HV: u64 = 1 << 6;
+const FLAG_EXCLUDE_IDLE: u64 = 1 << 7;
+const _FLAG_MMAP: u64 = 1 << 8;
+const FLAG_COMM: u64 = 1 << 9;
+const FLAG_FREQ: u64 = 1 << 10;
+const _FLAG_INHERIT_STAT: u64 = 1 << 11;
+const _FLAG_ENABLE_ON_EXEC: u64 = 1 << 12;
+const FLAG_TASK: u64 = 1 << 13;
+const _FLAG_WATERMARK: u64 = 1 << 14;
+const _FLAG_PRECISE_IP: u64 = 1 << 15;
+const _FLAG_PRECISE_NO_SKID: u64 = 1 << 16;
+const _FLAG_MMAP_DATA: u64 = 1 << 17;
+const FLAG_SAMPLE_ID_ALL: u64 = 1 << 18;
+const _FLAG_EXCLUDE_HOST: u64 = 1 << 19;
+const _FLAG_EXCLUDE_GUEST: u64 = 1 << 20;
+const FLAG_EXCLUDE_CALLCHAIN_KERNEL: u64 = 1 << 21;
+const FLAG_EXCLUDE_CALLCHAIN_USER: u64 = 1 << 22;
+const FLAG_MMAP2: u64 = 1 << 23;
+const FLAG_COMM_EXEC: u64 = 1 << 24;
+const FLAG_USE_CLOCKID: u64 = 1 << 25;
+const FLAG_CONTEXT_SWITCH: u64 = 1 << 26;
+const _FLAG_WRITE_BACKWARD: u64 = 1 << 27;
+const _FLAG_NAMESPACES: u64 = 1 << 28;
+const _FLAG_KSYMBOL: u64 = 1 << 29;
+const _FLAG_BPF_EVENT: u64 = 1 << 30;
+const _FLAG_AUX_OUTPUT: u64 = 1 << 31;
+const _FLAG_CGROUP: u64 = 1 << 32;
+const _FLAG_TEXT_POKE: u64 = 1 << 33;
+
+const _CLOCK_REALTIME: i32 = 0;
+const CLOCK_MONOTONIC_RAW: i32 = 4;
+
+const _PERF_TYPE_HARDWARE: u32 = 0;
+const PERF_TYPE_SOFTWARE: u32 = 1;
+const PERF_TYPE_TRACEPOINT: u32 = 2;
+
+const PERF_EVENT_IOC_ENABLE: i32 = 9216;
+const PERF_EVENT_IOC_DISABLE: i32 = 9217;
+const PERF_EVENT_IOC_SET_OUTPUT: i32 = 9221;
+
+const PERF_COUNT_SW_CPU_CLOCK: u64 = 0;
+const PERF_COUNT_SW_CONTEXT_SWITCHES: u64 = 3;
+const PERF_COUNT_SW_DUMMY: u64 = 9;
+
+const PERF_ATTR_SIZE_VER4: u32 = 104;
+
+#[repr(C)]
+#[derive(Copy)]
+#[derive(Clone)]
+#[derive(Default)]
+pub(crate) struct perf_event_attr {
+   event_type: u32,
+   size: u32,
+   config: u64,
+   sample_period_freq: u64,
+   sample_type: u64,
+   read_format: u64,
+   flags: u64,
+   wakeup_events_watermark: u32,
+   bp_type: u32,
+   bp_addr: u64,
+   bp_len: u64,
+   branch_sample_type: u64,
+   sample_regs_user: u64,
+   sample_stack_user: u32,
+   clockid: i32,
+   sample_regs_intr: u64,
+}
+
+impl perf_event_attr {
+    pub fn has_format(
+        &self,
+        format: u64) -> bool {
+        (self.sample_type & format) == format
+    }
+}
+
+pub struct RingBufOptions {
+    attributes: perf_event_attr,
+}
+
+impl Default for RingBufOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RingBufOptions {
+    fn common_attributes() -> perf_event_attr {
+        perf_event_attr {
+            size: PERF_ATTR_SIZE_VER4,
+            flags: FLAG_USE_CLOCKID |
+                FLAG_SAMPLE_ID_ALL |
+                FLAG_DISABLED |
+                FLAG_EXCLUDE_HV |
+                FLAG_EXCLUDE_IDLE,
+            clockid: CLOCK_MONOTONIC_RAW,
+            read_format: abi::PERF_FORMAT_ID,
+            sample_type: abi::PERF_SAMPLE_IDENTIFIER |
+                abi::PERF_SAMPLE_TIME |
+                abi::PERF_SAMPLE_TID,
+            /* Leave rest default */
+            .. Default::default()
+        }
+    }
+
+    fn attributes(&self) -> perf_event_attr {
+        self.attributes
+    }
+
+    pub fn new() -> Self {
+        Self {
+            attributes: Self::common_attributes(),
+        }
+    }
+
+    pub fn with_callchain_data(&self) -> Self {
+        let mut attributes = self.attributes;
+
+        attributes.sample_type |= abi::PERF_SAMPLE_CALLCHAIN;
+
+        Self {
+            attributes,
+        }
+    }
+
+    pub fn without_user_callchain_data(&self) -> Self {
+        let mut attributes = self.attributes;
+
+        attributes.flags |= FLAG_EXCLUDE_CALLCHAIN_USER;
+
+        Self {
+            attributes,
+        }
+    }
+
+    pub fn without_kernel_callchain_data(&self) -> Self {
+        let mut attributes = self.attributes;
+
+        attributes.flags |= FLAG_EXCLUDE_CALLCHAIN_KERNEL;
+
+        Self {
+            attributes,
+        }
+    }
+
+    pub fn with_user_regs_data(
+        &self,
+        regs: u64) -> Self {
+        let mut attributes = self.attributes;
+
+        attributes.sample_type |= abi::PERF_SAMPLE_REGS_USER;
+        attributes.sample_regs_user = regs;
+
+        Self {
+            attributes,
+        }
+    }
+
+    pub fn with_user_stack_data(
+        &self,
+        stack_bytes: u32) -> Self {
+        let mut attributes = self.attributes;
+
+        attributes.sample_type |= abi::PERF_SAMPLE_STACK_USER;
+        attributes.sample_stack_user = stack_bytes;
+
+        Self {
+            attributes,
+        }
+    }
+}
+
+fn perf_event_open(
+    attr: &perf_event_attr,
+    pid: i32,
+    cpu: i32,
+    group_fd: i32,
+    flags: usize) -> IOResult<usize> {
+    unsafe {
+        match syscalls::syscall5(
+            syscalls::Sysno::perf_event_open,
+            attr as *const perf_event_attr as usize,
+            pid as usize,
+            cpu as usize,
+            group_fd as usize,
+            flags) {
+            Ok(result) => Ok(result),
+            Err(error) => Err(error.into())
+        }
+    }
+}
+
+pub struct Profiling;
+pub struct ContextSwitches;
+pub struct Tracepoint;
+pub struct Kernel;
+
+pub struct RingBufBuilder<T = Profiling> {
+    attributes: perf_event_attr,
+    _type: PhantomData<T>,
+}
+
+impl RingBufBuilder {
+    pub fn for_kernel() -> RingBufBuilder<Kernel> {
+        let mut options = RingBufOptions::new();
+
+        options.attributes.event_type = PERF_TYPE_SOFTWARE;
+        options.attributes.config = PERF_COUNT_SW_DUMMY;
+
+        RingBufBuilder::<Kernel> {
+            attributes: options.attributes,
+            _type: PhantomData::<Kernel>,
+        }
+    }
+
+    pub fn for_cswitches(options: &RingBufOptions) -> RingBufBuilder<ContextSwitches> {
+        let mut attributes = options.attributes();
+
+        attributes.event_type = PERF_TYPE_SOFTWARE;
+        attributes.config = PERF_COUNT_SW_CONTEXT_SWITCHES;
+        attributes.sample_period_freq = 1;
+
+        RingBufBuilder::<ContextSwitches> {
+            attributes,
+            _type: PhantomData::<ContextSwitches>,
+        }
+    }
+
+    pub fn for_profiling(
+        options: &RingBufOptions,
+        sampling_frequency: u64) -> RingBufBuilder<Profiling> {
+        let mut attributes = options.attributes();
+
+        attributes.event_type = PERF_TYPE_SOFTWARE;
+        attributes.config = PERF_COUNT_SW_CPU_CLOCK;
+        attributes.sample_period_freq = sampling_frequency;
+        attributes.flags |= FLAG_FREQ;
+
+        RingBufBuilder::<Profiling> {
+            attributes,
+            _type: PhantomData::<Profiling>,
+        }
+    }
+
+    pub fn for_tracepoint(options: &RingBufOptions) -> RingBufBuilder<Tracepoint> {
+        let mut attributes = options.attributes();
+
+        attributes.event_type = PERF_TYPE_TRACEPOINT;
+        attributes.sample_period_freq = 1;
+
+        attributes.sample_type |= abi::PERF_SAMPLE_RAW;
+
+        RingBufBuilder::<Tracepoint> {
+            attributes,
+            _type: PhantomData::<Tracepoint>,
+        }
+    }
+}
+
+impl RingBufBuilder<Profiling> {
+    pub(crate) fn build(&self) -> CommonRingBuf {
+        CommonRingBuf::new(self.attributes)
+    }
+}
+
+impl RingBufBuilder<ContextSwitches> {
+    pub(crate) fn build(&self) -> CommonRingBuf {
+        CommonRingBuf::new(self.attributes)
+    }
+}
+
+impl RingBufBuilder<Tracepoint> {
+    pub(crate) fn build(
+        &self,
+        tracepoint_id: u64) -> CommonRingBuf {
+        let mut attributes = self.attributes;
+
+        /*
+         * We need to support live adding more events so we
+         * copy then update the tracepoint id live here.
+         */
+        attributes.config = tracepoint_id;
+
+        CommonRingBuf::new(attributes)
+    }
+}
+
+impl RingBufBuilder<Kernel> {
+    pub fn with_mmap_records(&self) -> Self {
+        let mut attributes = self.attributes;
+
+        attributes.flags |= FLAG_MMAP2;
+
+        Self {
+            attributes,
+            _type: self._type,
+        }
+    }
+
+    pub fn with_comm_records(&self) -> Self {
+        let mut attributes = self.attributes;
+
+        attributes.flags |= FLAG_COMM | FLAG_COMM_EXEC;
+
+        Self {
+            attributes,
+            _type: self._type,
+        }
+    }
+
+    pub fn with_task_records(&self) -> Self {
+        let mut attributes = self.attributes;
+
+        attributes.flags |= FLAG_TASK;
+
+        Self {
+            attributes,
+            _type: self._type,
+        }
+    }
+
+    pub fn with_cswitch_records(&self) -> Self {
+        let mut attributes = self.attributes;
+
+        attributes.flags |= FLAG_CONTEXT_SWITCH;
+
+        Self {
+            attributes,
+            _type: self._type,
+        }
+    }
+
+    pub(crate) fn build(&self) -> CommonRingBuf {
+        CommonRingBuf::new(self.attributes)
+    }
+}
+
+#[repr(C)]
+#[derive(Default)]
+struct read_format {
+    value: u64,
+    id: u64,
+}
+
+/* Libc calls */
+extern "C" {
+    fn sysconf(name: i32) -> isize;
+
+    fn mmap64(
+        addr: *mut u8,
+        len: isize,
+        prot: i32,
+        flags: i32,
+        fd: i32,
+        offset: u64) -> *mut u8;
+
+    fn read(
+        fd: i32,
+        buf: *mut u8,
+        count: usize) -> isize;
+
+    fn ioctl(
+        fd: i32,
+        req: i32,
+        ...) -> i32;
+
+    fn munmap(
+        pages: *mut u8,
+        len: isize) -> i32;
+
+    fn close(fd: i32) -> i32;
+}
+
+pub(crate) struct CommonRingBuf {
+    attributes: Rc<perf_event_attr>,
+}
+
+impl CommonRingBuf {
+    pub fn new(
+        attributes: perf_event_attr) -> Self {
+        Self {
+            attributes: Rc::new(attributes),
+        }
+    }
+
+    pub fn cpu_count(&self) -> u32 {
+        unsafe {
+            const SC_NPROCESSORS_ONLN: i32 = 84;
+
+            sysconf(SC_NPROCESSORS_ONLN) as u32
+        }
+    }
+
+    pub fn for_cpu(
+        &self,
+        cpu: u32) -> CpuRingBuf {
+        CpuRingBuf::new(
+            cpu,
+            self.attributes.clone())
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct CpuRingCursor {
+    start: u64,
+    end: u64,
+}
+
+impl CpuRingCursor {
+    pub fn set(
+        &mut self,
+        start: u64,
+        end: u64) {
+        self.start = start;
+        self.end = end;
+    }
+
+    pub fn advance(
+        &mut self,
+        len: u16) {
+        self.start += len as u64;
+    }
+
+    pub fn more(&self) -> bool {
+        self.start < self.end
+    }
+
+    pub fn start(&self) -> u64 {
+        self.start
+    }
+}
+
+pub(crate) struct CpuRingReader {
+    pages: *mut u8,
+    pages_len: isize,
+    data_offset: u64,
+    data_size: u64,
+    data_mask: u64,
+}
+
+impl<'a> CpuRingReader {
+    pub fn new(
+        pages: *mut u8,
+        pages_len: isize) -> Self {
+        let slice = unsafe {
+            std::slice::from_raw_parts(
+                pages,
+                pages_len as usize)
+        };
+
+        let data_offset = u64::from_ne_bytes(
+            slice[1040..1048].try_into().unwrap());
+
+        let data_size = u64::from_ne_bytes(
+            slice[1048..1056].try_into().unwrap());
+
+        Self {
+            pages,
+            pages_len,
+            data_offset,
+            data_size,
+            data_mask: data_size - 1,
+        }
+    }
+
+    fn slice(&self) -> &[u8] {
+        unsafe {
+            std::slice::from_raw_parts(
+                self.pages,
+                self.pages_len as usize)
+        }
+    }
+
+    pub fn begin_reading(
+        &self,
+        cursor: &mut CpuRingCursor) {
+        let head = self.head();
+
+        unsafe {
+            rmb();
+        }
+
+        let tail = self.tail();
+
+        cursor.set(tail, head);
+    }
+
+    pub fn data_slice(
+        &'a self) -> &'a [u8] {
+        let slice = self.slice();
+        let data_start = self.data_offset as usize;
+        let data_end = data_start + self.data_size as usize;
+        &slice[data_start..data_end]
+    }
+
+    pub fn peek_header(
+        &'a self,
+        cursor: &CpuRingCursor,
+        data_slice: &'a [u8],
+        start: &mut usize) -> IOResult<abi::Header> {
+        *start = (cursor.start() & self.data_mask) as usize;
+        let end = *start + abi::Header::data_offset();
+        let header_slice = &data_slice[*start .. end];
+
+        match abi::Header::from_slice(header_slice) {
+            Ok(header) => Ok(header),
+            Err(_) => { Err(io_error(
+                "Header slice was not large enough."))
+            }
+        }
+    }
+
+    pub fn peek_u64(
+        &self,
+        cursor: &CpuRingCursor,
+        offset: u64) -> u64 {
+        let start = ((cursor.start() + offset) & self.data_mask) as usize;
+        let end = start + 8;
+
+        let data_slice = self.data_slice();
+        u64::from_ne_bytes(data_slice[start..end].try_into().unwrap())
+    }
+
+    pub fn read(
+        &'a self,
+        cursor: &mut CpuRingCursor,
+        temp: &'a mut Vec<u8>) -> IOResult<&'a [u8]> {
+        let data_slice = self.data_slice();
+        let mut header_start = 0;
+
+        let header = self.peek_header(
+            cursor,
+            data_slice,
+            &mut header_start)?;
+
+        let data_size = header.size as usize;
+        let data_end = header_start + data_size;
+
+        cursor.advance(header.size);
+
+        if header_start + data_size <= self.data_size as usize {
+            /* Fits within slice, no copy */
+            Ok(&data_slice[header_start .. data_end])
+        } else {
+            /* Data wrapped, requires copy */
+            temp.clear();
+            temp.extend_from_slice(&data_slice[header_start..]);
+            let remaining = data_size - temp.len();
+            temp.extend_from_slice(&data_slice[0..remaining]);
+
+            Ok(&temp[0..])
+        }
+    }
+
+    pub fn end_reading(
+        &mut self,
+        cursor: &CpuRingCursor) {
+        unsafe {
+            mb();
+            let tail: *mut u64 = self.pages.offset(1032) as *mut u64;
+            *tail = cursor.start();
+        }
+    }
+
+    fn head(&self) -> u64 {
+        let slice = self.slice();
+        u64::from_ne_bytes(
+            slice[1024..1032].try_into().unwrap())
+    }
+
+    fn tail(&self) -> u64 {
+        let slice = self.slice();
+        u64::from_ne_bytes(
+            slice[1032..1040].try_into().unwrap())
+    }
+}
+
+impl Drop for CpuRingReader {
+    fn drop(&mut self) {
+        unsafe {
+            munmap(self.pages, self.pages_len);
+        }
+    }
+}
+
+pub(crate) struct CpuRingBuf {
+    cpu: u32,
+    attributes: Rc<perf_event_attr>,
+    sample_time_offset: u16,
+    fd: Option<i32>,
+    id: Option<u64>,
+}
+
+impl CpuRingBuf {
+    pub fn new(
+        cpu: u32,
+        attributes: Rc<perf_event_attr>) -> Self {
+        let mut sample_time_offset = abi::Header::data_offset() as u16;
+
+        if attributes.has_format(abi::PERF_SAMPLE_IDENTIFIER) {
+            sample_time_offset += 8;
+        }
+
+        if attributes.has_format(abi::PERF_SAMPLE_IP) {
+            sample_time_offset += 8;
+        }
+
+        if attributes.has_format(abi::PERF_SAMPLE_TID) {
+            sample_time_offset += 8;
+        }
+
+        Self {
+            cpu,
+            attributes,
+            sample_time_offset,
+            fd: None,
+            id: None,
+        }
+    }
+
+    fn read_id(&self) -> IOResult<u64> {
+        match &self.fd {
+            Some(fd) => {
+                let mut id = read_format::default();
+
+                unsafe {
+                    let result = read(
+                        *fd,
+                        &mut id as *mut read_format as *mut u8,
+                        16);
+
+                    if result == -1 {
+                        return Err(IOError::last_os_error());
+                    }
+                }
+
+                Ok(id.id)
+            },
+
+            None => Err(io_error(
+                "Ring buffer is not open."))
+        }
+    }
+
+    pub fn sample_time_offset(&self) -> u16 {
+        self.sample_time_offset
+    }
+
+    pub fn sample_format(&self) -> u64 {
+        self.attributes.sample_type
+    }
+
+    pub fn flags(&self) -> u64 {
+        self.attributes.flags
+    }
+
+    pub fn user_regs(&self) -> u64 {
+        self.attributes.sample_regs_user
+    }
+
+    pub fn read_format(&self) -> u64 {
+        self.attributes.read_format
+    }
+
+    pub fn id(&self) -> Option<u64> {
+        self.id
+    }
+
+    pub fn open(
+        &mut self,
+        target_pid: Option<i32>) -> IOResult<()> {
+        let pid = target_pid.unwrap_or(-1);
+
+        let fd = perf_event_open(
+            &self.attributes,
+            pid,
+            self.cpu as i32,
+            -1,
+            0)?;
+
+        self.fd = Some(fd as i32);
+        self.id = Some(self.read_id()?);
+
+        Ok(())
+    }
+
+    pub fn create_reader(
+        &self,
+        page_count: usize) -> IOResult<CpuRingReader> {
+        if self.fd.is_none() {
+            return Err(io_error(
+                "Ring buffer is not open."));
+        }
+
+        let page_count = page_count.next_power_of_two() + 1;
+
+        unsafe {
+            const SC_PAGE_SIZE: i32 = 30;
+            const PROT_READ: i32 = 1;
+            const PROT_WRITE: i32 = 2;
+            const MAP_SHARED: i32 = 1;
+            const MAP_FAILED: *mut u8 = !0 as *mut u8;
+
+            let page_size = sysconf(SC_PAGE_SIZE);
+            let pages_len = page_count as isize * page_size;
+
+            let pages = mmap64(
+                std::ptr::null_mut::<u8>(),
+                pages_len,
+                PROT_READ | PROT_WRITE,
+                MAP_SHARED,
+                self.fd.unwrap(),
+                0);
+
+            if pages == MAP_FAILED {
+                return Err(IOError::last_os_error());
+            }
+
+            Ok(CpuRingReader::new(
+                pages,
+                pages_len))
+        }
+    }
+
+    pub fn enable(
+        &self) -> IOResult<()> {
+        if self.fd.is_none() {
+            return Err(io_error(
+                "Ring buffer is not open."));
+        }
+
+        unsafe {
+            let result = ioctl(
+                self.fd.unwrap(),
+                PERF_EVENT_IOC_ENABLE);
+
+            if result != 0 {
+                return Err(IOError::last_os_error());
+            }
+        };
+
+        Ok(())
+    }
+
+    pub fn disable(
+        &self) -> IOResult<()> {
+        if self.fd.is_none() {
+            return Err(io_error(
+                "Ring buffer is not open."));
+        }
+
+        unsafe {
+            let result = ioctl(
+                self.fd.unwrap(),
+                PERF_EVENT_IOC_DISABLE);
+
+            if result != 0 {
+                return Err(IOError::last_os_error());
+            }
+        };
+
+        Ok(())
+    }
+
+    pub fn redirect_to(
+        &self, 
+        target: &Self) -> IOResult<()> {
+        if self.fd.is_none() || target.fd.is_none() {
+            return Err(io_error(
+                "Ring buffer or target is not open."));
+        }
+
+        unsafe {
+            let result = ioctl(
+                self.fd.unwrap(),
+                PERF_EVENT_IOC_SET_OUTPUT,
+                target.fd.unwrap());
+
+            if result == -1 {
+                return Err(IOError::last_os_error());
+            }
+
+            Ok(())
+        }
+    }
+}
+
+impl Drop for CpuRingBuf {
+    fn drop(&mut self) {
+        if let Some(fd) = self.fd {
+            unsafe {
+                close(fd);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn swap(
+        source: &[u8],
+        dest: &mut [u8]) {
+        let mut i: usize = 0;
+
+        for b in source {
+            dest[i] = *b;
+            i += 1;
+        }
+    }
+
+    #[test]
+    fn reader() {
+        let mut temp = Vec::new();
+
+        let mut data = Vec::new();
+        data.resize(2 * 4096, 0);
+
+        let slice = data.as_mut_slice();
+
+        /* Data Offset: 4096 */
+        swap(
+            &4096u64.to_ne_bytes(),
+            &mut slice[1040..1048]);
+
+        /* Data Size: 4096 */
+        swap(
+            &4096u64.to_ne_bytes(),
+            &mut slice[1048..1056]);
+
+        /* Write a few entries */
+        let mut entry = Vec::new();
+
+        /* 1 */
+        abi::Header::write(1024, 0, &1u64.to_ne_bytes(), &mut entry);
+
+        /* 2 */
+        abi::Header::write(1024, 0, &2u64.to_ne_bytes(), &mut entry);
+
+        /* 3 */
+        abi::Header::write(1024, 0, &3u64.to_ne_bytes(), &mut entry);
+
+        /* Add entry to ring buffer */
+        swap(
+            entry.as_slice(),
+            &mut slice[4096..]);
+
+        /* Head position */
+        swap(
+            &(entry.len() as u64).to_ne_bytes(),
+            &mut slice[1024..1032]);
+
+        /* Tail position */
+        swap(
+            &0u64.to_ne_bytes(),
+            &mut slice[1032..1040]);
+
+        let mut reader = CpuRingReader::new(
+            data.as_mut_ptr(),
+            data.len() as isize);
+
+        let mut cursor = CpuRingCursor::default();
+        reader.begin_reading(&mut cursor);
+
+        assert_eq!(true, cursor.more());
+
+        /* 1 */
+        let read = reader.read(&mut cursor, &mut temp).unwrap();
+        let header = abi::Header::from_slice(read).unwrap();
+        assert_eq!(1024, header.entry_type);
+        assert_eq!(16, header.size);
+        assert_eq!(16, read.len());
+        assert_eq!(1, u64::from_ne_bytes(read[8..16].try_into().unwrap()));
+
+        /* 2 */
+        let read = reader.read(&mut cursor, &mut temp).unwrap();
+        let header = abi::Header::from_slice(read).unwrap();
+        assert_eq!(1024, header.entry_type);
+        assert_eq!(16, header.size);
+        assert_eq!(16, read.len());
+        assert_eq!(2, u64::from_ne_bytes(read[8..16].try_into().unwrap()));
+
+        /* 3 */
+        let read = reader.read(&mut cursor, &mut temp).unwrap();
+        let header = abi::Header::from_slice(read).unwrap();
+        assert_eq!(1024, header.entry_type);
+        assert_eq!(16, header.size);
+        assert_eq!(16, read.len());
+        assert_eq!(3, u64::from_ne_bytes(read[8..16].try_into().unwrap()));
+
+        /* Reading after end results in 0 sized slice */
+        assert_eq!(false, cursor.more());
+        let read = reader.read(&mut cursor, &mut temp).unwrap();
+        assert_eq!(0, read.len());
+
+        reader.end_reading(&cursor);
+        drop(reader);
+
+        let slice = data.as_mut_slice();
+
+        /* Add wrapping entry */
+        entry.clear();
+
+        /* 4 */
+        abi::Header::write(1024, 0, &4u64.to_ne_bytes(), &mut entry);
+
+        /* Add entry to ring buffer */
+        swap(
+            &entry.as_slice()[0..8],
+            &mut slice[8184..8192]);
+
+        swap(
+            &entry.as_slice()[8..16],
+            &mut slice[4096..4104]);
+
+        /* Head position: 8200 */
+        swap(
+            &8200u64.to_ne_bytes(),
+            &mut slice[1024..1032]);
+
+        /* Tail position: 8184 */
+        swap(
+            &8184u64.to_ne_bytes(),
+            &mut slice[1032..1040]);
+
+        let mut reader = CpuRingReader::new(
+            data.as_mut_ptr(),
+            data.len() as isize);
+
+        reader.begin_reading(&mut cursor);
+
+        assert_eq!(true, cursor.more());
+
+        /* 4 */
+        let read = reader.read(&mut cursor, &mut temp).unwrap();
+        let header = abi::Header::from_slice(read).unwrap();
+        assert_eq!(1024, header.entry_type);
+        assert_eq!(16, header.size);
+        assert_eq!(16, read.len());
+        assert_eq!(4, u64::from_ne_bytes(read[8..16].try_into().unwrap()));
+
+        /* Reading after end results in 0 sized slice */
+        assert_eq!(false, cursor.more());
+        let read = reader.read(&mut cursor, &mut temp).unwrap();
+        assert_eq!(0, read.len());
+
+        reader.end_reading(&cursor);
+
+        /* Ensure update stuck */
+        reader.begin_reading(&mut cursor);
+        assert_eq!(false, cursor.more());
+        reader.end_reading(&cursor);
+    }
+
+    #[test]
+    #[ignore]
+    fn open_close() {
+        println!("NOTE: Requires sudo/SYS_CAP_ADMIN/tracefs access.");
+
+        let cpu = 0;
+        let pid = Some(0);
+        let mut rb_head = RingBufBuilder::for_kernel().build().for_cpu(cpu);
+
+        rb_head.open(pid).unwrap();
+
+        let kernel = RingBufBuilder::for_kernel()
+            .with_mmap_records();
+
+        let page_count = 1;
+        let _reader = rb_head.create_reader(page_count).unwrap();
+
+        let mut rb = kernel.build().for_cpu(cpu);
+        rb.open(pid).unwrap();
+        rb.redirect_to(&rb_head).unwrap();
+        rb.enable().unwrap();
+    }
+}

--- a/one_collect/src/perf_event/rb/source.rs
+++ b/one_collect/src/perf_event/rb/source.rs
@@ -1,0 +1,589 @@
+use super::*;
+
+pub struct RingBufSessionBuilder {
+    pages: usize,
+    target_pid: Option<i32>,
+    kernel_builder: Option<RingBufBuilder<Kernel>>,
+    event_builder: Option<RingBufBuilder<Tracepoint>>,
+    profiling_builder: Option<RingBufBuilder<Profiling>>,
+    cswitch_builder: Option<RingBufBuilder<ContextSwitches>>,
+}
+
+impl Default for RingBufSessionBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RingBufSessionBuilder {
+    pub fn new() -> Self {
+        Self {
+            pages: 1,
+            target_pid: None,
+            kernel_builder: None,
+            event_builder: None,
+            profiling_builder: None,
+            cswitch_builder: None,
+        }
+    }
+
+    pub fn with_target_pid(
+        &mut self,
+        pid: i32) -> Self {
+        Self {
+            pages: self.pages,
+            target_pid: Some(pid),
+            kernel_builder: self.kernel_builder.take(),
+            event_builder: self.event_builder.take(),
+            profiling_builder: self.profiling_builder.take(),
+            cswitch_builder: self.cswitch_builder.take(),
+        }
+    }
+
+    pub fn with_page_count(
+        &mut self,
+        pages: usize) -> Self {
+        Self {
+            pages,
+            target_pid: self.target_pid.take(),
+            kernel_builder: self.kernel_builder.take(),
+            event_builder: self.event_builder.take(),
+            profiling_builder: self.profiling_builder.take(),
+            cswitch_builder: self.cswitch_builder.take(),
+        }
+    }
+
+    pub fn with_kernel_events(
+        &mut self,
+        builder: RingBufBuilder<Kernel>) -> Self {
+        Self {
+            pages: self.pages,
+            target_pid: self.target_pid.take(),
+            kernel_builder: Some(builder),
+            event_builder: self.event_builder.take(),
+            profiling_builder: self.profiling_builder.take(),
+            cswitch_builder: self.cswitch_builder.take(),
+        }
+    }
+
+    pub fn with_tracepoint_events(
+        &mut self,
+        builder: RingBufBuilder<Tracepoint>) -> Self {
+        Self {
+            pages: self.pages,
+            target_pid: self.target_pid.take(),
+            kernel_builder: self.kernel_builder.take(),
+            event_builder: Some(builder),
+            profiling_builder: self.profiling_builder.take(),
+            cswitch_builder: self.cswitch_builder.take(),
+        }
+    }
+
+    pub fn with_profiling_events(
+        &mut self,
+        builder: RingBufBuilder<Profiling>) -> Self {
+        Self {
+            pages: self.pages,
+            target_pid: self.target_pid.take(),
+            kernel_builder: self.kernel_builder.take(),
+            event_builder: self.event_builder.take(),
+            profiling_builder: Some(builder),
+            cswitch_builder: self.cswitch_builder.take(),
+        }
+    }
+
+    pub fn with_cswitch_events(
+        &mut self,
+        builder: RingBufBuilder<ContextSwitches>) -> Self {
+        Self {
+            pages: self.pages,
+            target_pid: self.target_pid.take(),
+            kernel_builder: self.kernel_builder.take(),
+            event_builder: self.event_builder.take(),
+            profiling_builder: self.profiling_builder.take(),
+            cswitch_builder: Some(builder),
+        }
+    }
+
+    pub fn build(&mut self) -> IOResult<PerfSession> {
+        let mut source = RingBufDataSource::new(
+            self.pages,
+            self.target_pid.take(),
+            self.kernel_builder.take(),
+            self.event_builder.take(),
+            self.profiling_builder.take(),
+            self.cswitch_builder.take());
+
+        source.build()?;
+
+        Ok(PerfSession::new(Box::new(source)))
+    }
+}
+
+pub struct RingBufDataSource {
+    readers: Vec<CpuRingReader>,
+    cursors: Vec<CpuRingCursor>,
+    temp: Vec<u8>,
+    leader_ids: HashMap<u32, u64>,
+    ring_bufs: HashMap<u64, CpuRingBuf>,
+    pages: usize,
+    enabled: bool,
+    target_pid: Option<i32>,
+    kernel_builder: Option<RingBufBuilder<Kernel>>,
+    event_builder: Option<RingBufBuilder<Tracepoint>>,
+    profiling_builder: Option<RingBufBuilder<Profiling>>,
+    cswitch_builder: Option<RingBufBuilder<ContextSwitches>>,
+    next_time: Option<u64>,
+    oldest_cpu: Option<usize>,
+}
+
+impl RingBufDataSource {
+    fn new(
+        pages: usize,
+        target_pid: Option<i32>,
+        kernel_builder: Option<RingBufBuilder<Kernel>>,
+        event_builder: Option<RingBufBuilder<Tracepoint>>,
+        profiling_builder: Option<RingBufBuilder<Profiling>>,
+        cswitch_builder: Option<RingBufBuilder<ContextSwitches>>) -> Self {
+        Self {
+            readers: Vec::new(),
+            cursors: Vec::new(),
+            temp: Vec::new(),
+            leader_ids: HashMap::new(),
+            ring_bufs: HashMap::new(),
+            pages,
+            target_pid,
+            kernel_builder,
+            event_builder,
+            profiling_builder,
+            cswitch_builder,
+            next_time: None,
+            oldest_cpu: None,
+            enabled: false,
+        }
+    }
+
+    fn add_cpu_bufs(
+        target_pid: Option<i32>,
+        leader_ids: &HashMap<u32, u64>,
+        ring_bufs: &mut HashMap<u64, CpuRingBuf>,
+        common_buf: CommonRingBuf) -> IOResult<()> {
+        /*
+         * Utility function to allocate per-cpu buffers and
+         * redirect them to the kernel leader buffers on the
+         * same CPU.
+         */
+        for i in 0..common_buf.cpu_count() {
+            let leader_id = leader_ids[&i];
+            let leader = &ring_bufs[&leader_id];
+            let mut cpu_buf = common_buf.for_cpu(i);
+
+            cpu_buf.open(target_pid)?;
+
+            match cpu_buf.id() {
+                Some(id) => {
+                    cpu_buf.redirect_to(leader)?;
+
+                    ring_bufs.insert(id, cpu_buf);
+                },
+                None => {
+                    return Err(io_error(
+                        "Internal error getting buffer ID."));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn build(&mut self) -> IOResult<()> {
+        /* Always required */
+        let common = self.kernel_builder
+            .get_or_insert_with(RingBufBuilder::for_kernel)
+            .build();
+
+        /* Build the kernel only dummy rings first */
+        for i in 0..common.cpu_count() {
+            let mut cpu_buf = common.for_cpu(i);
+
+            cpu_buf.open(self.target_pid)?;
+
+            match cpu_buf.id() {
+                Some(id) => {
+                    self.leader_ids.insert(i, id);
+
+                    /* We need to map these in, and only these */
+                    let reader = cpu_buf.create_reader(self.pages)?;
+                    self.readers.push(reader);
+                    self.cursors.push(CpuRingCursor::default());
+
+                    self.ring_bufs.insert(id, cpu_buf);
+                },
+                None => {
+                    return Err(io_error(
+                        "Internal error getting buffer ID."));
+                }
+            }
+        }
+
+        /* Add in profiling samples and redirect to kernel outputs */
+        if let Some(profiling_builder) = self.profiling_builder.as_mut() {
+            let common = profiling_builder.build();
+
+            Self::add_cpu_bufs(
+                self.target_pid,
+                &self.leader_ids,
+                &mut self.ring_bufs,
+                common)?;
+        }
+
+        /* Add in cswitch samples and redirect to kernel outputs */
+        if let Some(cswitch_builder) = self.cswitch_builder.as_mut() {
+            let common = cswitch_builder.build();
+
+            Self::add_cpu_bufs(
+                self.target_pid,
+                &self.leader_ids,
+                &mut self.ring_bufs,
+                common)?;
+        }
+
+        Ok(())
+    }
+
+    fn enable(&mut self) -> IOResult<()> {
+        for rb in self.ring_bufs.values() {
+            rb.enable()?;
+        }
+
+        self.enabled = true;
+
+        Ok(())
+    }
+
+    fn disable(&mut self) -> IOResult<()> {
+        for rb in self.ring_bufs.values() {
+            rb.disable()?;
+        }
+
+        self.enabled = false;
+
+        Ok(())
+    }
+
+    fn read_time<'a>(
+        reader: &'a CpuRingReader,
+        cursor: &'a CpuRingCursor,
+        ring_bufs: &'a HashMap<u64, CpuRingBuf>) -> Option<(u64, &'a CpuRingBuf)> {
+        let mut start = 0;
+        let slice = reader.data_slice();
+
+        /* No more data means no time */
+        if !cursor.more() {
+            return None;
+        }
+
+        match reader.peek_header(
+            cursor,
+            slice,
+            &mut start) {
+            Ok(header) => {
+                let id_offset: u16;
+                let mut time_offset: Option<u16> = None;
+
+                if header.entry_type == abi::PERF_RECORD_SAMPLE {
+                    /* Sample records have a static id offset only */
+                    id_offset = abi::Header::data_offset() as u16;
+                } else {
+                    /* Non-Sample records have both static offsets */
+                    time_offset = Some(header.size - 16);
+                    id_offset = header.size - 8;
+                }
+
+                /* All cases require to fetch the id */
+                let id = reader.peek_u64(
+                    cursor,
+                    id_offset as u64);
+
+                /* Fetch the buffer */
+                let buf = &ring_bufs[&id];
+
+                /* Time offset is not set, must be a sample */
+                if time_offset.is_none() {
+                    /* Fetch per-buffer time offset */
+                    time_offset = Some(buf.sample_time_offset());
+                }
+
+                /* Peek time */
+                let time = reader.peek_u64(
+                    cursor,
+                    time_offset.unwrap() as u64);
+
+                /* Give back time and sample format to use */
+                Some((time, buf))
+            },
+            Err(_) => None,
+        }
+    }
+
+    fn find_current_buffer(
+        &mut self) {
+        let mut oldest_time: Option<u64> = None;
+        let mut next_time: Option<u64> = None;
+        let mut oldest_cpu: Option<usize> = None;
+
+        for i in 0..self.readers.len() {
+            let reader = &mut self.readers[i];
+            let cursor = &mut self.cursors[i];
+
+            if let Some((time, _rb)) = Self::read_time(
+                reader,
+                cursor,
+                &self.ring_bufs) {
+                match oldest_time {
+                    Some(prev_time) => {
+                        if time < prev_time {
+                            next_time = oldest_time;
+                            oldest_time = Some(time);
+                            oldest_cpu = Some(i);
+                        } else {
+                            match next_time {
+                                Some(current_next_time) => {
+                                    if time < current_next_time {
+                                        next_time = Some(time);
+                                    }
+                                },
+                                None => {
+                                    next_time = Some(time);
+                                }
+                            }
+                        }
+                    },
+                    None => {
+                        oldest_time = Some(time);
+                        oldest_cpu = Some(i);
+                    },
+                }
+            }
+        }
+
+        self.oldest_cpu = oldest_cpu;
+        self.next_time = next_time;
+    }
+}
+
+impl PerfDataSource for RingBufDataSource {
+    fn enable(&mut self) -> IOResult<()> {
+        self.enable()
+    }
+
+    fn disable(&mut self) -> IOResult<()> {
+        self.disable()
+    }
+
+    fn add_event(
+        &mut self,
+        event: &Event) -> IOResult<()> {
+        /* Add in all the events and redirect to kernel outputs */
+        if let Some(event_builder) = self.event_builder.as_mut() {
+            let common = event_builder.build(event.id() as u64);
+
+            Self::add_cpu_bufs(
+                self.target_pid,
+                &self.leader_ids,
+                &mut self.ring_bufs,
+                common)?;
+        }
+
+        Ok(())
+    }
+
+    fn begin_reading(&mut self) {
+        for i in 0..self.readers.len() {
+            let reader = &mut self.readers[i];
+            let cursor = &mut self.cursors[i];
+
+            reader.begin_reading(cursor);
+        }
+
+        self.find_current_buffer();
+    }
+
+    fn read(
+        &mut self,
+        timeout: Duration) -> Option<PerfData<'_>> {
+        /* Bail if we couldn't find a current buffer */
+        if self.oldest_cpu.is_none() {
+            std::thread::sleep(timeout);
+            return None;
+        }
+
+        let cpu = self.oldest_cpu.unwrap();
+        let reader = &self.readers[cpu];
+        let cursor = &mut self.cursors[cpu];
+
+        let sample_format: u64;
+        let flags: u64;
+        let user_regs: u64;
+        let read_format: u64;
+
+        /* Ensure current entry is still under the limit */
+        match Self::read_time(
+            reader,
+            cursor,
+            &self.ring_bufs) {
+            /* We have some data/time left in this buffer */
+            Some((time, rb)) => {
+                if let Some(next_time) = self.next_time {
+                    /* If older than next oldest, stop */
+                    if time > next_time {
+                        return None;
+                    }
+                }
+
+                /* Under limit, save off format details */
+                sample_format = rb.sample_format();
+                flags = rb.flags();
+                user_regs = rb.user_regs();
+                read_format = rb.read_format();
+            },
+            /* No data left, stop */
+            None => {
+                return None;
+            }
+        }
+
+        /* Read perf data */
+        match reader.read(
+            cursor,
+            &mut self.temp) {
+            Ok(raw_data) => {
+                let perf_data = PerfData {
+                    cpu: cpu as u32,
+                    sample_format,
+                    flags,
+                    user_regs,
+                    read_format,
+                    raw_data,
+                };
+
+                Some(perf_data)
+            },
+            Err(_) => None,
+        }
+    }
+
+    fn end_reading(&mut self) {
+        if let Some(oldest_cpu) = self.oldest_cpu {
+            let reader = &mut self.readers[oldest_cpu];
+            let cursor = &mut self.cursors[oldest_cpu];
+
+            reader.end_reading(cursor);
+        }
+    }
+
+    fn more(&self) -> bool {
+        if self.oldest_cpu.is_some() {
+            return true;
+        }
+
+        self.enabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn config() {
+        let kernel = RingBufBuilder::for_kernel()
+            .with_mmap_records()
+            .with_comm_records()
+            .with_task_records()
+            .with_cswitch_records();
+
+        let options = RingBufOptions::new()
+            .with_callchain_data();
+
+        let freq = 1000;
+
+        let profiling = RingBufBuilder::for_profiling(
+            &options,
+            freq);
+
+        let _builder = RingBufSessionBuilder::new()
+            .with_page_count(1)
+            .with_kernel_events(kernel)
+            .with_profiling_events(profiling);
+    }
+
+    #[test]
+    #[ignore]
+    fn profile() {
+        let options = RingBufOptions::new()
+            .with_callchain_data();
+
+        let freq = 1000;
+
+        let profiling = RingBufBuilder::for_profiling(
+            &options,
+            freq);
+
+        let mut session = RingBufSessionBuilder::new()
+            .with_page_count(8)
+            .with_profiling_events(profiling)
+            .build()
+            .unwrap();
+
+        session.set_read_timeout(Duration::from_millis(0));
+
+        let samples = Arc::new(AtomicUsize::new(0));
+
+        let callback_samples = samples.clone();
+
+        let time_data = session.time_data_ref();
+
+        let prof_event = session.profile_event();
+
+        let atomic_time = Arc::new(AtomicUsize::new(0));
+
+        prof_event.set_callback(move |full_data,_format,_event_data| {
+            let time = time_data.try_get_u64(full_data).unwrap() as usize;
+            let prev = atomic_time.load(Ordering::Relaxed);
+
+            /* Ensure in order */
+            assert!(time >= prev);
+
+            callback_samples.fetch_add(1, Ordering::Relaxed);
+            atomic_time.store(time, Ordering::Relaxed);
+        });
+
+        session.enable().unwrap();
+
+        /* Spin for 100 ms */
+        let now = std::time::Instant::now();
+
+        while now.elapsed().as_millis() < 100 {
+            /* Nothing */
+        }
+
+        session.disable().unwrap();
+
+        let now = std::time::Instant::now();
+
+        /* Parse all the samples */
+        session.parse_all().unwrap();
+
+        println!("Took {}us", now.elapsed().as_micros());
+
+        /* Ensure we got at least a sample per-ms */
+        let count = samples.load(Ordering::Relaxed);
+
+        println!("Got {} samples", count);
+        assert!(count >= 100);
+    }
+}


### PR DESCRIPTION
When collecting data we need a source to pull from. We can get ring buffers from the kernel via perf_event_open(). These are in-memory ring buffers which can get configured to either profile, get kernel events, or get tracepoint events (like those found in tracefs) as they are emitted.

There is a new struct called RingBufDataSource that abstracts all the ring buffer logic away from the PerfDataSource trait. There is also a new struct called RingBufSessionBuilder which builds both the RingBufDataSource and a PerfSession to aid in simplifying (and abstracting) how all the pieces fit together.

A quick basic example of setting up a system wide profiling session is:
let options = RingBufOptions::new()
    .with_callchain_data();

let freq = 1000;

let profiling = RingBufBuilder::for_profiling(
    &options,
    freq);

let mut session = RingBufSessionBuilder::new()
    .with_page_count(8)
    .with_profiling_events(profiling)
    .build()
    .unwrap();

session.profile_event().set_callback(
    move |full_data,format,event_data| {
        /* Process the sample */
    });

session.enable().unwrap();

session.parse_for_duration(
   std::time::Duration::from_secs(1)).unwrap();

session.disable().unwrap();

There are still a few other TODOs around this, like exposing which CPU the sample came from cleanly and clearly indicating events for CPU profiling and cswitch samples. But this puts the basic bones together that should make further changes much smaller and targetted.