### PR TITLE
Expose IOError and IOResult<T> in the root namespace

### DIFF
--- a/one_collect/src/lib.rs
+++ b/one_collect/src/lib.rs
@@ -5,3 +5,12 @@ pub mod perf_event;
 pub mod session;
 
 pub use sharing::{Writable, ReadOnly};
+
+pub type IOResult<T> = std::io::Result<T>;
+pub type IOError = std::io::Error;
+
+pub fn io_error(message: &str) -> IOError {
+    IOError::new(
+        std::io::ErrorKind::Other,
+        message)
+}

--- a/one_collect/src/perf_event/mod.rs
+++ b/one_collect/src/perf_event/mod.rs
@@ -3,6 +3,7 @@ use std::array::TryFromSliceError;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use super::*;
 use crate::sharing::*;
 use crate::event::*;
 
@@ -11,15 +12,6 @@ pub mod rb;
 mod events;
 
 use abi::*;
-
-pub type IOResult<T> = std::io::Result<T>;
-pub type IOError = std::io::Error;
-
-pub fn io_error(message: &str) -> IOError {
-    IOError::new(
-        std::io::ErrorKind::Other,
-        message)
-}
 
 pub use rb::source::RingBufSessionBuilder;
 pub use rb::{RingBufOptions, RingBufBuilder};

--- a/one_collect/src/session.rs
+++ b/one_collect/src/session.rs
@@ -1,7 +1,8 @@
 use std::io;
+
+use super::*;
 use crate::perf_event::PerfSession;
 use crate::perf_event::rb::{RingBufOptions, RingBufBuilder, source::RingBufSessionBuilder};
-pub type IOResult<T> = std::io::Result<T>;
 
 pub enum SessionEgress<'a> {
     File(FileSessionEgress<'a>),


### PR DESCRIPTION
Move `IOError` and `IOResult<T>` into the root namespace so that they are more globally available for use across the codebase.