### PR TITLE
Capture mmap records in capture_environment()

### DIFF
--- a/one_collect/src/helpers/callstack.rs
+++ b/one_collect/src/helpers/callstack.rs
@@ -526,6 +526,7 @@ mod tests {
             println!("WARN: Lost samples data");
         });
 
+        session.capture_environment();
         session.enable().unwrap();
         session.parse_for_duration(duration).unwrap();
         session.disable().unwrap();


### PR DESCRIPTION
Today we only capture comm records via capture_environment(). For proper stack unwinding or saving off the full machine state the current mmap records of each process also need to be captured.

Move exising capture_environment() into capture_environment_comms() and build a new cpature_environment_modules() for mmap records. Call both in a new version of capture_environment().

This movement/isolation is required to let the copy/borrow checker know that these are separate and can call self for each instance safely.