### PR TITLE
Introduce Error Reporting for Event Callbacks

### DIFF
--- a/cli/src/debug.rs
+++ b/cli/src/debug.rs
@@ -61,7 +61,7 @@ impl<'a> DebugConsoleSession<'a> {
         comm_event.add_callback( move |full_data,format,event_data| {
 
             // timestamp
-            let time = time_data.try_get_u64(full_data).unwrap_or(0) as usize;
+            let time = time_data.get_u64(full_data)? as usize;
 
             // cpu
             let mut cpu = 0;
@@ -70,15 +70,17 @@ impl<'a> DebugConsoleSession<'a> {
             });
 
             // pid
-            let pid = format.try_get_u32(comm_pid_ref, event_data).unwrap_or(0);
+            let pid = format.get_u32(comm_pid_ref, event_data)?;
 
             // tid
-            let tid = format.try_get_u32(comm_tid_ref, event_data).unwrap_or(0);
+            let tid = format.get_u32(comm_tid_ref, event_data)?;
 
             // comm
-            let comm_value = format.try_get_str(comm_comm_ref, event_data).unwrap_or("");
+            let comm_value = format.get_str(comm_comm_ref, event_data)?;
 
             println!("timestamp: {time}, event: comm, cpu: {cpu}, pid: {pid}, tid: {tid}, comm: {comm_value}");
+
+            Ok(())
         });
     }
 
@@ -96,7 +98,7 @@ impl<'a> DebugConsoleSession<'a> {
         exit_event.add_callback( move |full_data,format,event_data| {
 
             // timestamp
-            let time = time_data.try_get_u64(full_data).unwrap_or(0) as usize;
+            let time = time_data.get_u64(full_data)? as usize;
 
             // cpu
             let mut cpu = 0;
@@ -105,12 +107,14 @@ impl<'a> DebugConsoleSession<'a> {
             });
 
             // pid
-            let pid = format.try_get_u32(exit_pid_ref, event_data).unwrap_or(0);
+            let pid = format.get_u32(exit_pid_ref, event_data)?;
 
             // tid
-            let tid = format.try_get_u32(exit_tid_ref, event_data).unwrap_or(0);
+            let tid = format.get_u32(exit_tid_ref, event_data)?;
 
             println!("timestamp: {time}, event: exit, cpu: {cpu}, pid: {pid}, tid: {tid}");
+
+            Ok(())
         });
     }
 
@@ -126,7 +130,7 @@ impl<'a> DebugConsoleSession<'a> {
         perf_session.cpu_profile_event().add_callback( move |full_data,_format,_event_data| {
 
             // timestamp
-            let time = time_data.try_get_u64(full_data).unwrap_or(0) as usize;
+            let time = time_data.get_u64(full_data)? as usize;
 
             // cpu
             let mut cpu = 0;
@@ -135,10 +139,10 @@ impl<'a> DebugConsoleSession<'a> {
             });
 
             // pid
-            let pid = pid_field.try_get_u32(full_data).unwrap_or(0);
+            let pid = pid_field.get_u32(full_data)?;
 
             // tid
-            let tid = tid_field.try_get_u32(full_data).unwrap_or(0);
+            let tid = tid_field.get_u32(full_data)?;
 
             // session state
             // NOTE: This is what will be required in order to consume tracked state.
@@ -153,6 +157,8 @@ impl<'a> DebugConsoleSession<'a> {
                     println!("timestamp: {time}, event: cpu_profile, cpu: {cpu}, pid: {pid}, tid: {tid}");
                 }
             });
+
+            Ok(())
         });
     }
 
@@ -169,7 +175,7 @@ impl<'a> DebugConsoleSession<'a> {
         lost_event.add_callback(move |full_data,format,event_data| {
 
             // timestamp
-            let time = time_data.try_get_u64(full_data).unwrap_or(0) as usize;
+            let time = time_data.get_u64(full_data)? as usize;
 
             // cpu
             let mut cpu = 0;
@@ -178,12 +184,14 @@ impl<'a> DebugConsoleSession<'a> {
             });
 
             // id
-            let id = format.try_get_u64(id_field, event_data).unwrap();
+            let id = format.get_u64(id_field, event_data)?;
 
             // lost
-            let lost = format.try_get_u64(lost_field, event_data).unwrap();
+            let lost = format.get_u64(lost_field, event_data)?;
 
             println!("timestamp: {time}, event: lost, cpu: {cpu}, id: {id}, lost: {lost}");
+
+            Ok(())
         });
     }
 
@@ -199,7 +207,7 @@ impl<'a> DebugConsoleSession<'a> {
         lost_samples_event.add_callback(move |full_data,format,event_data| {
 
             // timestamp
-            let time = time_data.try_get_u64(full_data).unwrap_or(0) as usize;
+            let time = time_data.get_u64(full_data)? as usize;
 
             // cpu
             let mut cpu = 0;
@@ -208,9 +216,11 @@ impl<'a> DebugConsoleSession<'a> {
             });
 
             // lost
-            let lost = format.try_get_u64(lost_field, event_data).unwrap();
+            let lost = format.get_u64(lost_field, event_data)?;
 
             println!("timestamp: {time}, event: lost, cpu: {cpu}, lost: {lost}");
+
+            Ok(())
         });
     }
 

--- a/one_collect/Cargo.toml
+++ b/one_collect/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 syscalls = { version = "0.6.13", features = ["x86_64", "arm"] }
+anyhow = "1.0.75"
 ruwind = { path = "../ruwind" }
 
 [dev-dependencies]

--- a/one_collect/benches/event.rs
+++ b/one_collect/benches/event.rs
@@ -29,6 +29,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         assert!(a[0] == 1u8);
         assert!(b[0] == 2u8);
         assert!(c[0] == 3u8);
+
+        Ok(())
     });
 
     let mut data: Vec<u8> = Vec::new();
@@ -37,8 +39,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     data.push(3u8);
 
     let slice = data.as_slice();
+    let mut errors = Vec::new();
 
-    c.bench_function("min_parse", |b| b.iter(|| e.process(slice, slice)));
+    c.bench_function("min_parse", |b| b.iter(|| {
+        e.process(slice, slice, &mut errors);
+        errors.clear();
+    }));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/one_collect/examples/perf_cpu.rs
+++ b/one_collect/examples/perf_cpu.rs
@@ -47,6 +47,8 @@ impl Utilization {
                 session_util.write(|usage| {
                     usage.per_cpu[cpu as usize] += 1;
                 });
+
+                Ok(())
             });
 
         /* Give back the shared writable */

--- a/one_collect/src/perf_event/rb/source.rs
+++ b/one_collect/src/perf_event/rb/source.rs
@@ -696,6 +696,8 @@ mod tests {
 
             callback_samples.fetch_add(1, Ordering::Relaxed);
             atomic_time.store(time, Ordering::Relaxed);
+
+            Ok(())
         });
 
         session.enable().unwrap();

--- a/one_collect/src/sharing.rs
+++ b/one_collect/src/sharing.rs
@@ -35,6 +35,14 @@ impl<T> SharedData<T, DataOwner> {
         f(&mut self.inner.borrow_mut());
     }
 
+    pub fn borrow_mut(&self) -> std::cell::RefMut<'_, T> {
+        self.inner.borrow_mut()
+    }
+
+    pub fn borrow(&self) -> std::cell::Ref<'_, T> {
+        self.inner.borrow()
+    }
+
     pub fn read_only(&self) -> SharedData<T, DataReader> {
         SharedData::<T, DataReader> {
             inner: self.inner.clone(),
@@ -65,6 +73,10 @@ impl<T: Copy> SharedData<T, DataOwner> {
 }
 
 impl<T> SharedData<T, DataReader> {
+    pub fn borrow(&self) -> std::cell::Ref<'_, T> {
+        self.inner.borrow()
+    }
+
     pub fn read(
         &self,
         f: impl FnOnce(&T)) {


### PR DESCRIPTION
Currently event callbacks cannot report any errors they encounter. We want to be able to track when errors occur and from which events during processing.

Modify the event callback signature to return a Result<(), anyhow::Error>. Pull in the anyhow crate, which lets the event callbacks use any error they wish, instead of relying upon a single one. This makes the callbacks trivial to write with error handling as the ? operator can now be used for any method that returns a Result<T, E> regardless of the E type.

Update Event.process() to take in a Vec< anyhow::Error > to store errors. Add a self test for event callbacks to ensures errors are propogating out properly to the Vec. Errors are stored accumulative, so programs can either accumulate all of the errors or process/log them as they arrive. The PerfSession logs to the standard error by default, callers can override this by calling PerfSession.set_event_error_callback() to do something more custom.

Update all callers of Event.process() and Event.add_callback() to do the right thing now. This means our callbacks no longer unwrap() and cause a panic nor do they assume a default value for invalid data. In all cases an error is returned if the data is not in the intended format or size.