### PR TITLE
Expose Callstacks in Session Struct and Debug Command

### DIFF
--- a/one_collect/src/session.rs
+++ b/one_collect/src/session.rs
@@ -3,8 +3,9 @@ use std::io;
 use std::time::Duration;
 
 use super::*;
+use crate::helpers::callstack::{CallstackHelper, CallstackReader, CallstackHelp};
 use crate::perf_event::PerfSession;
-use crate::perf_event::rb::{RingBufOptions, RingBufBuilder, source::RingBufSessionBuilder};
+use crate::perf_event::rb::{RingBufBuilder, source::RingBufSessionBuilder};
 use crate::state::ProcessTrackingOptions;
 
 pub enum SessionEgress<'a> {
@@ -32,6 +33,7 @@ pub struct SessionBuilder<'a> {
     egress: SessionEgress<'a>,
     with_profiling: bool,
     with_call_stacks: bool,
+    page_count: usize,
     profiling_frequency : u64,
     process_tracking_options: ProcessTrackingOptions,
 }
@@ -42,6 +44,7 @@ impl<'a> SessionBuilder<'a> {
             egress,
             with_profiling: false,
             with_call_stacks: false,
+            page_count: 8,
             profiling_frequency: 1000,
             process_tracking_options: ProcessTrackingOptions::default(),
         }
@@ -58,6 +61,7 @@ impl<'a> SessionBuilder<'a> {
     pub fn with_call_stacks(self) -> Self {
         Self {
             with_call_stacks: true,
+            page_count: 256,
             ..self
         }
     }
@@ -77,25 +81,55 @@ impl<'a> SessionBuilder<'a> {
 pub struct Session<'a> {
     egress: SessionEgress<'a>,
     perf_session: Option<PerfSession>,
+    stack_reader: Option<CallstackReader>,
 }
 
 impl<'a> Session<'a> {
     pub(crate) fn build(builder: SessionBuilder<'a>) -> Result<Self, io::Error> {
-        let perf_session: Option<PerfSession>;
+
+        let mut stack_reader = None;
+
+        let mut ring_buf_builder = RingBufSessionBuilder::new()
+            .with_page_count(builder.page_count);
+
         if builder.with_profiling {
-            match Self::build_perf_session(&builder) {
-                Ok(session) => perf_session = Some(session),
-                Err(e) => return Err(e),
-            }
-        }
-        else {
-            perf_session = None;
+            let profiling_builder = RingBufBuilder::for_profiling(
+                builder.profiling_frequency);
+
+            ring_buf_builder = ring_buf_builder.with_profiling_events(profiling_builder);
         }
 
-        Ok(Self {
+        if builder.with_call_stacks {
+            let stack_helper = CallstackHelper::new()
+                .with_dwarf_unwinding();
+
+            ring_buf_builder = ring_buf_builder.with_callstack_help(&stack_helper);
+            stack_reader = Some(stack_helper.to_reader());
+        }
+
+        // Enable comm events by default.
+        let kernel_builder = RingBufBuilder::for_kernel()
+            .with_comm_records();
+        ring_buf_builder = ring_buf_builder.with_kernel_events(kernel_builder);
+
+        // Enable process tracking if requested.
+        if builder.process_tracking_options.any() {
+            ring_buf_builder = ring_buf_builder.track_process_state(
+                builder.process_tracking_options);
+        }
+
+        let mut session = Self {
             egress: builder.egress,
-            perf_session,
-        })
+            perf_session: None,
+            stack_reader,
+        };
+
+        match ring_buf_builder.build() {
+            Ok(perf_session) => session.perf_session = Some(perf_session),
+            Err(e) => return Err(e),
+        }
+
+        Ok(session)
     }
 
     pub fn egress_info(&self) -> &SessionEgress<'a> {
@@ -142,35 +176,10 @@ impl<'a> Session<'a> {
         }
     }
 
-    fn build_perf_session(builder: &SessionBuilder<'a>) -> IOResult<PerfSession> {
-        let mut ring_buf_builder = RingBufSessionBuilder::new()
-            .with_page_count(8);
-
-        // Enable comm events by default.
-        let kernel_builder = RingBufBuilder::for_kernel()
-            .with_comm_records();
-        ring_buf_builder = ring_buf_builder.with_kernel_events(kernel_builder);
-
-        // Enable profiling if requested.
-        if builder.with_profiling {
-            let mut profiling_builder = RingBufBuilder::for_profiling(
-                builder.profiling_frequency);
-
-            // Enable call stacks if requested.
-            if builder.with_call_stacks {
-                profiling_builder = profiling_builder.with_callchain_data();
-            }
-
-            ring_buf_builder = ring_buf_builder.with_profiling_events(profiling_builder);
+    pub fn stack_reader(&self) -> Option<CallstackReader> {
+        match &self.stack_reader {
+            Some(reader) => Some(reader.clone()),
+            None => None
         }
-
-        // Enable process tracking if requested.
-        if builder.process_tracking_options.any() {
-            ring_buf_builder = ring_buf_builder.track_process_state(
-                builder.process_tracking_options)
-        }
-
-        ring_buf_builder.build()
     }
-
 }


### PR DESCRIPTION
Exposes the ability to configure call stack unwind and capture using the Session struct.  This is enabled by a call to
SessionBuilder::with_call_stacks().

Adds the ability to display (currently unresolved) call stacks for each event by specifying -c or --callstacks to the cli debug command.