### PR TITLE
Exporting: Allow sampling Event callstacks

### DIFF
--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -12,7 +12,7 @@ use crate::perf_event::{RingBufSessionBuilder, RingBufBuilder};
 use crate::perf_event::abi::PERF_RECORD_MISC_SWITCH_OUT;
 
 const KERNEL_START:u64 = 0x800000000000;
-const KERNEL_END:u64 = 0xFFFFFFFFFFFF;
+const KERNEL_END:u64 = 0xFFFFFFFFFFFFFFFF;
 
 pub mod symbols;
 pub use symbols::{


### PR DESCRIPTION
Typically, in addition to CPU and context switches, callers will want to record callstacks for events within tracefs.

Add a with_event() extension to ExportSettings that takes an Event and adds hooks to make it easy to add a sample type for the event.

Add callbacks with_event() utilizes for setting up the samples as well as for creating them. Callers can be as little as a single value passed and the callstack will be recorded with a default sample type (setup by the builder or the event name if not).

The callbacks are written in a way that callers can parse further event details to either get the value for the sample within the payload. Or the events could be eventually saved somewhere instead of being treated as a sample.

This allows us to have a single pipeline for both saving samples and raw/metadata into the exporter, eventually.