### PR TITLE
Properly Set the End Address in KernelSymbolReader

### DIFF
--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -12,7 +12,7 @@ use crate::perf_event::{RingBufSessionBuilder, RingBufBuilder};
 use crate::perf_event::abi::PERF_RECORD_MISC_SWITCH_OUT;
 
 const KERNEL_START:u64 = 0x800000000000;
-const KERNEL_END:u64 = 0xFFFFFFFFFFFFFFFF;
+pub const KERNEL_END:u64 = 0xFFFFFFFFFFFFFFFF;
 
 pub mod graph;
 pub mod formats;


### PR DESCRIPTION
KernelSymbolReader reads one line of /proc/kallsyms at a time. Each line contains the start address, type of symbol, and the symbol itself.  The end address is the start address of the next line minus one. In cases where the next line is not a symbol for code in the text section, rather than skip the line, we should save the end address prior to skipping the line.