### PR TITLE
Perf: Fix multi-pid taking PIDs

### DIFF
--- a/one_collect/src/perf_event/rb/source.rs
+++ b/one_collect/src/perf_event/rb/source.rs
@@ -408,9 +408,11 @@ impl RingBufDataSource {
             .get_or_insert_with(RingBufBuilder::for_kernel)
             .build();
 
-        let pids = match self.target_pids.take() {
+        let empty_pids = Vec::new();
+
+        let pids = match &self.target_pids {
             Some(pids) => { pids },
-            None => { Vec::new() },
+            None => { &empty_pids },
         };
 
         /* Build the kernel only dummy rings first */
@@ -466,7 +468,7 @@ impl RingBufDataSource {
                     &common,
                     None)?;
             } else {
-                for pid in &pids {
+                for pid in pids {
                     Self::add_cpu_bufs(
                         Some(*pid),
                         &self.leader_ids,
@@ -489,7 +491,7 @@ impl RingBufDataSource {
                     &common,
                     None)?;
             } else {
-                for pid in &pids {
+                for pid in pids {
                     Self::add_cpu_bufs(
                         Some(*pid),
                         &self.leader_ids,


### PR DESCRIPTION
The multi-pid feature took the target_pids ownership and left it set as None.

Change to a reference model that avoids having to take it and leaving it set to None for future events.