### PR TITLE
Exporting: Allow samples to be copied

### DIFF
--- a/one_collect/src/helpers/exporting/process.rs
+++ b/one_collect/src/helpers/exporting/process.rs
@@ -10,6 +10,7 @@ use ruwind::{CodeSection, Unwindable};
 
 use super::*;
 
+#[derive(Clone, Copy)]
 pub struct ExportProcessSample {
     time: u64,
     value: u64,


### PR DESCRIPTION
ExportProcessSamples are sometimes used as temporary values until full calculations can be made. To do this, we need to ensure they can be copied or cloned.

Derive Copy and Clone for ExportProcessSamples.