### PR TITLE
Exporting: Make add_custom_sample public

### DIFF
--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -730,7 +730,7 @@ impl ExportMachine {
         Ok(())
     }
 
-    fn add_custom_sample(
+    pub fn add_custom_sample(
         &mut self,
         pid: u32,
         sample: ExportProcessSample) -> anyhow::Result<()> {


### PR DESCRIPTION
Missed adding this as public, this fixes that.