### PR TITLE
Event: Add EventData for callbacks

### DIFF
--- a/cli/src/debug.rs
+++ b/cli/src/debug.rs
@@ -95,7 +95,10 @@ impl<'a> DebugConsoleSession<'a> {
         let comm_tid_ref = comm_event_format.get_field_ref_unchecked("tid");
         let comm_comm_ref = comm_event_format.get_field_ref_unchecked("comm[]");
 
-        comm_event.add_callback( move |full_data,format,event_data| {
+        comm_event.add_callback( move |data| {
+            let full_data = data.full_data();
+            let format = data.format();
+            let event_data = data.event_data();
 
             // timestamp
             let time = time_data.get_u64(full_data)? as usize;
@@ -132,7 +135,10 @@ impl<'a> DebugConsoleSession<'a> {
         let exit_pid_ref = exit_event_format.get_field_ref_unchecked("pid");
         let exit_tid_ref = exit_event_format.get_field_ref_unchecked("tid");
 
-        exit_event.add_callback( move |full_data,format,event_data| {
+        exit_event.add_callback( move |data| {
+            let full_data = data.full_data();
+            let format = data.format();
+            let event_data = data.event_data();
 
             // timestamp
             let time = time_data.get_u64(full_data)? as usize;
@@ -166,7 +172,8 @@ impl<'a> DebugConsoleSession<'a> {
         let pid_field = perf_session.pid_field_ref();
         let tid_field = perf_session.tid_data_ref();
 
-        perf_session.cpu_profile_event().add_callback( move |full_data,_format,_event_data| {
+        perf_session.cpu_profile_event().add_callback( move |data| {
+            let full_data = data.full_data();
 
             // timestamp
             let time = time_data.get_u64(full_data)? as usize;
@@ -224,7 +231,10 @@ impl<'a> DebugConsoleSession<'a> {
         let id_field = lost_event_format.get_field_ref_unchecked("id");
         let lost_field = lost_event_format.get_field_ref_unchecked("lost");
 
-        lost_event.add_callback(move |full_data,format,event_data| {
+        lost_event.add_callback(move |data| {
+            let full_data = data.full_data();
+            let format = data.format();
+            let event_data = data.event_data();
 
             // timestamp
             let time = time_data.get_u64(full_data)? as usize;
@@ -256,7 +266,10 @@ impl<'a> DebugConsoleSession<'a> {
         let lost_samples_event_format = lost_samples_event.format();
         let lost_field = lost_samples_event_format.get_field_ref_unchecked("lost");
 
-        lost_samples_event.add_callback(move |full_data,format,event_data| {
+        lost_samples_event.add_callback(move |data| {
+            let full_data = data.full_data();
+            let format = data.format();
+            let event_data = data.event_data();
 
             // timestamp
             let time = time_data.get_u64(full_data)? as usize;

--- a/one_collect/benches/event.rs
+++ b/one_collect/benches/event.rs
@@ -21,7 +21,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let second = format.get_field_ref("2").unwrap();
     let third = format.get_field_ref("3").unwrap();
 
-    e.add_callback(move |_full_data, format, data| {
+    e.add_callback(move |data| {
+        let format = data.format();
+        let data = data.event_data();
+
         let a = format.get_data(first, data);
         let b = format.get_data(second, data);
         let c = format.get_data(third, data);

--- a/one_collect/examples/perf_bpf.rs
+++ b/one_collect/examples/perf_bpf.rs
@@ -27,7 +27,10 @@ fn main() {
     let pid_field = session.pid_field_ref();
     let time_field = session.time_data_ref();
 
-    event.add_callback(move |full_data, _format, event_data| {
+    event.add_callback(move |data| {
+        let full_data = data.full_data();
+        let event_data = data.event_data();
+
         println!("CPU={}, PID={}, Time={}, Data={} Bytes:",
             ancillary.borrow().cpu(),
             pid_field.get_u32(full_data)?,
@@ -71,13 +74,13 @@ fn main() {
         map_path,
         event).expect("Attach should work");
 
-    session.lost_event().add_callback(|_,_,_| {
+    session.lost_event().add_callback(|_| {
         println!("WARN: Lost event data");
 
         Ok(())
     });
 
-    session.lost_samples_event().add_callback(|_,_,_| {
+    session.lost_samples_event().add_callback(|_| {
         println!("WARN: Lost samples data");
 
         Ok(())

--- a/one_collect/examples/perf_cpu.rs
+++ b/one_collect/examples/perf_cpu.rs
@@ -37,7 +37,7 @@ impl Utilization {
         /* Setup to inc cpu by 1 on each cpu profile */
         session
             .cpu_profile_event()
-            .add_callback(move |_full_data,_event_format,_event_data| {
+            .add_callback(move |_| {
                 let mut cpu: u32 = 0;
 
                 ancillary.read(|values| {

--- a/one_collect/examples/perf_export.rs
+++ b/one_collect/examples/perf_export.rs
@@ -39,13 +39,13 @@ fn main() {
 
     let exporter = session.build_exporter(settings).unwrap();
 
-    session.lost_event().add_callback(|_,_,_| {
+    session.lost_event().add_callback(|_| {
         println!("WARN: Lost event data");
 
         Ok(())
     });
 
-    session.lost_samples_event().add_callback(|_,_,_| {
+    session.lost_samples_event().add_callback(|_| {
         println!("WARN: Lost samples data");
 
         Ok(())

--- a/one_collect/examples/perf_switch.rs
+++ b/one_collect/examples/perf_switch.rs
@@ -50,7 +50,11 @@ fn main() {
     let final_output = output.clone();
     let mut i = 0u64;
 
-    cswitch.add_callback(move |full_data,format,event_data| {
+    cswitch.add_callback(move |data| {
+        let full_data = data.full_data();
+        let format = data.format();
+        let event_data = data.event_data();
+
         let pid = format.get_u32(next_prev_pid, event_data)?;
 
         if pid == 0 {

--- a/one_collect/examples/uprobe_allocs.rs
+++ b/one_collect/examples/uprobe_allocs.rs
@@ -71,7 +71,10 @@ fn main() -> Result<(), anyhow::Error> {
     let swap = total.clone();
     let size_ref = alloc_event.format().get_field_ref_unchecked("size");
 
-    alloc_event.add_callback(move |_full_data,format,event_data| {
+    alloc_event.add_callback(move |data| {
+        let format = data.format();
+        let event_data = data.event_data();
+
         let size = format.get_u64(size_ref, event_data)?;
         total.write(|value| { *value += size; });
         Ok(())

--- a/one_collect/src/helpers/callstack.rs
+++ b/one_collect/src/helpers/callstack.rs
@@ -606,7 +606,10 @@ impl CallstackHelp for RingBufSessionBuilder {
                 let filename = fmt.get_field_ref_unchecked("filename[]");
                 let state = session_state.clone();
 
-                event.add_callback(move |_full_data,fmt,data| {
+                event.add_callback(move |data| {
+                    let fmt = data.format();
+                    let data = data.event_data();
+
                     let prot = fmt.get_u32(prot, data)? as i32;
 
                     /* Skip non-executable mmaps */
@@ -636,7 +639,10 @@ impl CallstackHelp for RingBufSessionBuilder {
                 let tid = fmt.get_field_ref_unchecked("tid");
                 let state = session_state.clone();
 
-                event.add_callback(move |_full_data,fmt,data| {
+                event.add_callback(move |data| {
+                    let fmt = data.format();
+                    let data = data.event_data();
+
                     let pid = fmt.get_u32(pid, data)?;
                     let tid = fmt.get_u32(tid, data)?;
 
@@ -659,7 +665,10 @@ impl CallstackHelp for RingBufSessionBuilder {
                 let tid = fmt.get_field_ref_unchecked("tid");
                 let state = session_state.clone();
 
-                event.add_callback(move |_full_data,fmt,data| {
+                event.add_callback(move |data| {
+                    let fmt = data.format();
+                    let data = data.event_data();
+
                     let pid = fmt.get_u32(pid, data)?;
                     let tid = fmt.get_u32(tid, data)?;
 
@@ -682,7 +691,10 @@ impl CallstackHelp for RingBufSessionBuilder {
                 let pid = fmt.get_field_ref_unchecked("pid");
                 let state = session_state.clone();
 
-                event.add_callback(move |_full_data,fmt,data| {
+                event.add_callback(move |data| {
+                    let fmt = data.format();
+                    let data = data.event_data();
+
                     let pid = fmt.get_u32(pid, data)?;
 
                     state.write(|state| {
@@ -725,7 +737,9 @@ mod tests {
         let bad_count = Writable::new(0u64);
         let callback_count = bad_count.clone();
 
-        waking.add_callback(move |full_data,_fmt,_data| {
+        waking.add_callback(move |data| {
+            let full_data = data.full_data();
+
             frames.clear();
 
             stack_reader.read_frames(
@@ -779,7 +793,9 @@ mod tests {
         let event = session.cpu_profile_event();
         let mut frames = Vec::new();
 
-        event.add_callback(move |full_data,_fmt,_data| {
+        event.add_callback(move |data| {
+            let full_data = data.full_data();
+
             let pid = pid_field.try_get_u32(full_data).unwrap();
             frames.clear();
 
@@ -798,13 +814,13 @@ mod tests {
             Ok(())
         });
 
-        session.lost_event().add_callback(|_,_,_| {
+        session.lost_event().add_callback(|_| {
             println!("WARN: Lost event data");
 
             Ok(())
         });
 
-        session.lost_samples_event().add_callback(|_,_,_| {
+        session.lost_samples_event().add_callback(|_| {
             println!("WARN: Lost samples data");
 
             Ok(())

--- a/one_collect/src/helpers/dotnet.rs
+++ b/one_collect/src/helpers/dotnet.rs
@@ -302,7 +302,10 @@ impl DotNetHelp for RingBufSessionBuilder {
                     let perfmap = Writable::new(tracker);
                     let perfmap_close = perfmap.clone();
 
-                    event.add_callback(move |_full_data,fmt,data| {
+                    event.add_callback(move |data| {
+                        let fmt = data.format();
+                        let data = data.event_data();
+
                         let prot = fmt.get_u32(prot, data)? as i32;
 
                         /* Skip non-executable mmaps */
@@ -325,7 +328,7 @@ impl DotNetHelp for RingBufSessionBuilder {
                     /* When session drops, stop worker thread */
                     let event = session.drop_event();
 
-                    event.add_callback(move |_full_data,_fmt,_data| {
+                    event.add_callback(move |_| {
                         perfmap_close.borrow_mut().disable()
                     });
                 }

--- a/one_collect/src/perf_event/mod.rs
+++ b/one_collect/src/perf_event/mod.rs
@@ -351,7 +351,10 @@ impl PerfSession {
         let mut path_buf = PathBuf::new();
         path_buf.push("/proc");
 
-        comm_event.add_callback(move |_full_data, format, event_data| {
+        comm_event.add_callback(move |data| {
+            let format = data.format();
+            let event_data = data.event_data();
+
             let pid = format.get_u32(pid_field, event_data)?;
             let tid = format.get_u32(tid_field, event_data)?;
 
@@ -389,7 +392,10 @@ impl PerfSession {
         let pid_field: EventFieldRef = fork_event_format.get_field_ref_unchecked("pid");
         let ppid_field = fork_event_format.get_field_ref_unchecked("ppid");
 
-        fork_event.add_callback(move |_full_data, format, event_data| {
+        fork_event.add_callback(move |data| {
+            let format = data.format();
+            let event_data = data.event_data();
+
             let pid = format.get_u32(pid_field, event_data)?;
             let ppid = format.get_u32(ppid_field, event_data)?;
 
@@ -406,7 +412,10 @@ impl PerfSession {
         let pid_field = exit_event_format.get_field_ref_unchecked("pid");
         let tid_field = exit_event_format.get_field_ref_unchecked("tid");
 
-        exit_event.add_callback(move |_full_data, format, event_data| {
+        exit_event.add_callback(move |data| {
+            let format = data.format();
+            let event_data = data.event_data();
+
             let pid = format.get_u32(pid_field, event_data)?;
             let tid = format.get_u32(tid_field, event_data)?;
 
@@ -1390,7 +1399,10 @@ mod tests {
         let second = format.get_field_ref("2").unwrap();
         let third = format.get_field_ref("3").unwrap();
 
-        e.add_callback(move |_full_data, format, event_data| {
+        e.add_callback(move |data| {
+            let format = data.format();
+            let event_data = data.event_data();
+
             let a = format.get_data(first, event_data);
             let b = format.get_data(second, event_data);
             let c = format.get_data(third, event_data);
@@ -1499,7 +1511,11 @@ mod tests {
         let magic_ref = format.get_field_ref("magic").unwrap();
 
         /* Parse upon being read with this code */
-        e.add_callback(move |full_data, format, event_data| {
+        e.add_callback(move |data| {
+            let full_data = data.full_data();
+            let format = data.format();
+            let event_data = data.event_data();
+
             let read_time = time_data.try_get_u64(full_data).unwrap();
             let read_magic = format.try_get_u64(magic_ref, event_data).unwrap();
 

--- a/one_collect/src/perf_event/rb/source.rs
+++ b/one_collect/src/perf_event/rb/source.rs
@@ -857,7 +857,9 @@ mod tests {
 
         let atomic_time = Arc::new(AtomicUsize::new(0));
 
-        prof_event.add_callback(move |full_data,_format,_event_data| {
+        prof_event.add_callback(move |data| {
+            let full_data = data.full_data();
+
             let time = time_data.try_get_u64(full_data).unwrap() as usize;
             let prev = atomic_time.load(Ordering::Relaxed);
             let mut cpu: u32 = 0;


### PR DESCRIPTION
Currently Event has a callback signature that is passed the event_data, format and full_data. If we need to add more, that would require all callers to change their closure signatures.

Make the callback signature take a single parameter of an EventData reference. This way, we can expand this over time without breaking existing users. This will cause a one-time breaking change, but there is minimal users, so it's better to do so now than later.