### PR TITLE
procfs: Report all modules, not just exec modules

### DIFF
--- a/one_collect/src/helpers/uprobe.rs
+++ b/one_collect/src/helpers/uprobe.rs
@@ -65,6 +65,10 @@ pub fn enum_uprobe_modules(
     pid: u32,
     mut callback: impl FnMut(&str)) {
     iter_proc_modules(pid, |module| {
+        if !module.is_exec() {
+            return;
+        }
+
         if let Some(path) = module.path {
             if !path.starts_with("[") {
                 callback(path);

--- a/one_collect/src/perf_event/mod.rs
+++ b/one_collect/src/perf_event/mod.rs
@@ -1194,7 +1194,7 @@ impl PerfSession {
         let id_bytes = 0u64.to_ne_bytes();
 
         procfs::iter_modules(move |pid, module| {
-            if module.path.is_none() {
+            if !module.is_exec() || module.path.is_none() {
                 return;
             }
 


### PR DESCRIPTION
Tools leveraging one-collect need to sometimes find module details for non-exec modules.

Extend the ModuleInfo struct to track the permissions (read, write, exec, private) and expose these via public methods.

Update existing callers of iter_proc_modules() and iter_modules() to check for is_exec() on the modules to ensure they work as before.