### PR TITLE
ARM: Ensure ARM64 works properly

### DIFF
--- a/one_collect/src/helpers/callstack.rs
+++ b/one_collect/src/helpers/callstack.rs
@@ -383,12 +383,18 @@ impl CallstackHelper {
         clone
     }
 
+    #[cfg(target_arch = "x86_64")]
     pub fn with_dwarf_unwinding(&mut self) -> Self {
         let mut clone = self.clone_mut();
 
         clone.unwinder = Some(Box::new(default_unwinder()));
 
         clone
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub fn with_dwarf_unwinding(&mut self) -> Self {
+        self.clone_mut()
     }
 
     pub fn with_stack_size(

--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -15,7 +15,7 @@ use crate::perf_event::abi::PERF_RECORD_MISC_SWITCH_OUT;
 
 use ruwind::ModuleAccessor;
 
-const KERNEL_START:u64 = 0x800000000000;
+const KERNEL_START:u64 = 0xFFFF800000000000;
 const KERNEL_END:u64 = 0xFFFFFFFFFFFFFFFF;
 
 pub type ExportDevNode = ruwind::ModuleKey;

--- a/one_collect/src/openat.rs
+++ b/one_collect/src/openat.rs
@@ -163,7 +163,11 @@ impl OpenAt {
                     break;
                 }
 
+                #[cfg(target_arch = "x86_64")]
                 let name = &(*entry).d_name as *const i8;
+                #[cfg(target_arch = "aarch64")]
+                let name = &(*entry).d_name as *const u8;
+
                 let len = libc::strlen(name);
 
                 let name = std::str::from_utf8_unchecked(


### PR DESCRIPTION
ARM64 is important to ensure works properly. There are a few differences in our codebase (and others) for ARM64 we need to address.

Handle the libc difference between u8/i8 for strlen, etc.

Handle lack of dwarf unwinding for ARM64.

Fix kernel layout address to ensure all architectures have the right start/end address.