### PR TITLE
ETW: Async Callstack Pattern

### DIFF
--- a/one_collect/src/etw/mod.rs
+++ b/one_collect/src/etw/mod.rs
@@ -255,6 +255,8 @@ impl SessionCallbackContext {
 }
 
 type SendClosure = Box<dyn Fn(&SessionCallbackContext) + Send + 'static>;
+type NoSendClosure = Box<dyn Fn(&SessionCallbackContext) + 'static>;
+type SessionClosure = Box<dyn Fn(&mut EtwSession) -> anyhow::Result<()> + 'static>;
 
 pub struct EtwSession {
     enabled: HashMap<Guid, TraceEnable>,
@@ -263,10 +265,11 @@ pub struct EtwSession {
 
     /* Callbacks */
     event_error_callback: Option<Box<dyn Fn(&Event, &anyhow::Error)>>,
+    built_callbacks: Option<Vec<SessionClosure>>,
     starting_callbacks: Option<Vec<SendClosure>>,
     started_callbacks: Option<Vec<SendClosure>>,
     stopping_callbacks: Option<Vec<SendClosure>>,
-    stopped_callbacks: Option<Vec<SendClosure>>,
+    stopped_callbacks: Option<Vec<NoSendClosure>>,
 
     /* Ancillary data */
     ancillary: Writable<AncillaryData>,
@@ -310,6 +313,7 @@ impl EtwSession {
 
             /* Callbacks */
             event_error_callback: None,
+            built_callbacks: Some(Vec::new()),
             starting_callbacks: Some(Vec::new()),
             started_callbacks: Some(Vec::new()),
             stopping_callbacks: Some(Vec::new()),
@@ -324,10 +328,22 @@ impl EtwSession {
         }
     }
 
+    pub fn needs_kernel_callstacks(&self) -> bool {
+        !self.kernel_callstacks.is_empty()
+    }
+
     pub fn set_event_error_callback(
         &mut self,
         callback: impl Fn(&Event, &anyhow::Error) + 'static) {
         self.event_error_callback = Some(Box::new(callback));
+    }
+
+    pub fn add_built_callback(
+        &mut self,
+        callback: impl Fn(&mut EtwSession) -> anyhow::Result<()> + 'static) {
+        if let Some(callbacks) = self.built_callbacks.as_mut() {
+            callbacks.push(Box::new(callback));
+        }
     }
 
     pub fn add_starting_callback(
@@ -356,7 +372,7 @@ impl EtwSession {
 
     pub fn add_stopped_callback(
         &mut self,
-        callback: impl Fn(&SessionCallbackContext) + Send + 'static) {
+        callback: impl Fn(&SessionCallbackContext) + 'static) {
         if let Some(callbacks) = self.stopped_callbacks.as_mut() {
             callbacks.push(Box::new(callback));
         }
@@ -794,6 +810,13 @@ impl EtwSession {
         until: impl FnOnce() + Send + 'static) -> anyhow::Result<()> {
         let mut session = TraceSession::new(name.into());
 
+        /* Run self mutating callbacks for on-demand dynamic hooks */
+        if let Some(callbacks) = self.built_callbacks.take() {
+            for callback in callbacks {
+                callback(&mut self)?;
+            }
+        }
+
         if self.elevate {
             session.enable_privilege("SeDebugPrivilege");
             session.enable_privilege("SeSystemProfilePrivilege");
@@ -805,11 +828,11 @@ impl EtwSession {
 
         session.start()?;
 
+        let handle = session.handle();
+
         if !self.kernel_callstacks.is_empty() {
             session.enable_kernel_callstacks(&self.kernel_callstacks)?;
         }
-        
-        let handle = session.handle();
 
         let enabled = self.take_enabled();
         let mut events = self.take_events();
@@ -817,7 +840,6 @@ impl EtwSession {
         let starting_callbacks = self.starting_callbacks.take();
         let started_callbacks = self.started_callbacks.take();
         let stopping_callbacks = self.stopping_callbacks.take();
-        let stopped_callbacks = self.stopped_callbacks.take();
 
         let thread = thread::spawn(move || -> anyhow::Result<()> {
             let context = SessionCallbackContext::new(handle);
@@ -877,13 +899,6 @@ impl EtwSession {
 
             TraceSession::remote_stop(handle);
 
-            /* Run stopped hooks */
-            if let Some(callbacks) = stopped_callbacks {
-                for callback in callbacks {
-                    callback(&context);
-                }
-            }
-
             Ok(())
         });
 
@@ -931,6 +946,15 @@ impl EtwSession {
                 }
             }
         }));
+
+        let context = SessionCallbackContext::new(0);
+
+        /* Run stopped hooks */
+        if let Some(callbacks) = &self.stopped_callbacks {
+            for callback in callbacks {
+                callback(&context);
+            }
+        }
 
         if result.is_err() {
             return result;

--- a/one_collect/src/event/mod.rs
+++ b/one_collect/src/event/mod.rs
@@ -384,6 +384,17 @@ impl EventFormat {
         &self.fields
     }
 
+    /// Returns a reference to an `EventField` based on the reference.
+    ///
+    /// # Returns
+    ///
+    /// An `EventField` if the field exists, panics otherwise.
+    pub fn get_field_unchecked(
+        &self,
+        field: EventFieldRef) -> &EventField {
+        &self.fields[usize::from(field)]
+    }
+
     /// Returns a reference to an `EventField` in the `fields` vector based on its name, if it exists.
     /// This method does not perform any bounds checking.
     ///
@@ -393,7 +404,7 @@ impl EventFormat {
     ///
     /// # Returns
     ///
-    /// An `EventFieldRef` if a field with the given name exists, `None` otherwise.
+    /// An `EventFieldRef` if a field with the given name exists, panics otherwise.
     pub fn get_field_ref_unchecked(
         &self,
         name: &str) -> EventFieldRef {

--- a/one_collect/src/helpers/callstack/mod.rs
+++ b/one_collect/src/helpers/callstack/mod.rs
@@ -5,8 +5,40 @@ pub mod os;
 pub type CallstackReader = os::CallstackReader;
 pub type CallstackHelper = os::CallstackHelper;
 
+const KERNEL_START:u64 = 0xFFFF800000000000;
+
 pub trait CallstackHelp {
     fn with_callstack_help(
         self,
         helper: &CallstackHelper) -> Self;
+}
+
+#[derive(Default)]
+pub struct PartialCallstack {
+    frames: Vec<u64>
+}
+
+impl PartialCallstack {
+    pub fn frames(&self) -> &[u64] { &self.frames }
+
+    pub fn is_empty(&self) -> bool { self.frames.is_empty() }
+
+    pub fn frames_end_in_userspace(
+        frames: &[u64]) -> bool {
+        let len = frames.len();
+
+        len > 0 && frames[len-1] < KERNEL_START
+    }
+
+    pub fn ends_in_userspace(&self) -> bool {
+        Self::frames_end_in_userspace(self.frames())
+    }
+
+    pub fn add_frames(
+        &mut self,
+        frames: &[u64]) {
+        self.frames.extend_from_slice(frames);
+    }
+
+    pub fn clear(&mut self) { self.frames.clear(); }
 }

--- a/one_collect/src/helpers/callstack/os/windows.rs
+++ b/one_collect/src/helpers/callstack/os/windows.rs
@@ -1,9 +1,188 @@
+use std::collections::HashMap;
+use std::collections::hash_map::Drain;
+use std::collections::hash_map::Entry::{Vacant, Occupied};
+
 use super::*;
 use crate::{Writable, ReadOnly};
 use crate::etw::*;
 
+struct PartialThreadCallstacks {
+    pid: u32,
+    tid: u32,
+    partials: HashMap<u64, PartialCallstack>,
+}
+
+impl PartialThreadCallstacks {
+    fn new(
+        pid: u32,
+        tid: u32) -> Self {
+        Self {
+            pid,
+            tid,
+            partials: HashMap::default(),
+        }
+    }
+
+    fn flush(&mut self) -> Drain<u64, PartialCallstack> {
+        self.partials.drain()
+    }
+
+    fn add_frames<'a>(
+        &'a mut self,
+        time: u64,
+        frames: &'a [u64],
+        buffer: &'a mut Vec<u64>) -> Option<&'a [u64]> {
+        let user_stack = PartialCallstack::frames_end_in_userspace(frames);
+
+        match self.partials.entry(time) {
+            Vacant(entry) => {
+                if user_stack {
+                    /* Return immediately, since user mode only stack */
+                    return Some(frames);
+                }
+
+                /* Kernel stack, save for userspace */
+                let mut partial = PartialCallstack::default();
+
+                partial.add_frames(frames);
+
+                entry.insert(partial);
+
+                None
+            },
+            Occupied(mut entry) => {
+                if user_stack {
+                    let partial = entry.remove();
+
+                    buffer.clear();
+                    buffer.extend_from_slice(partial.frames());
+                    buffer.extend_from_slice(frames);
+
+                    Some(&buffer[..])
+                } else {
+                    entry.get_mut().add_frames(frames);
+
+                    None
+                }
+            }
+        }
+    }
+}
+
+pub struct CompletedCallstack<'a> {
+    time: u64,
+    pid: u32,
+    tid: u32,
+    frames: &'a [u64],
+}
+
+impl<'a> CompletedCallstack<'a> {
+    fn new(
+        time: u64,
+        pid: u32,
+        tid: u32,
+        frames: &'a [u64]) -> Self {
+        Self {
+            time,
+            pid,
+            tid,
+            frames,
+        }
+    }
+
+    pub fn time(&self) -> u64 { self.time }
+
+    pub fn pid(&self) -> u32 { self.pid }
+
+    pub fn tid(&self) -> u32 { self.tid }
+
+    pub fn frames(&'a self) -> &'a [u64] { self.frames }
+
+    fn notify(
+        &self,
+        callbacks: &mut Vec<Box<dyn FnMut(&CompletedCallstack)>>) {
+        for callback in callbacks {
+            callback(self);
+        }
+    }
+}
+
+#[derive(Default)]
+struct PartialCallstackLookup {
+    stacks: HashMap<u64, PartialThreadCallstacks>,
+    buffer: Vec<u64>,
+    flushed_callbacks: Vec<Box<dyn FnMut()>>,
+    frames_callbacks: Vec<Box<dyn FnMut(&CompletedCallstack)>>,
+}
+
+impl PartialCallstackLookup {
+    fn add_flushed_callback(
+        &mut self,
+        callback: impl FnMut() + 'static) {
+        self.flushed_callbacks.push(Box::new(callback));
+    }
+
+    fn add_frames_callback(
+        &mut self,
+        callback: impl FnMut(&CompletedCallstack) + 'static) {
+        self.frames_callbacks.push(Box::new(callback));
+    }
+
+    fn flush(&mut self) {
+        for (key, mut stacks) in self.stacks.drain() {
+            let pid = (key >> 32 & 0xFFFF) as u32;
+            let tid = (key & 0xFFFF) as u32;
+
+            for (time, stack) in stacks.flush() {
+                let full = CompletedCallstack::new(
+                    time,
+                    pid,
+                    tid,
+                    stack.frames());
+
+                full.notify(&mut self.frames_callbacks);
+            }
+        }
+
+        for callback in &mut self.flushed_callbacks {
+            callback();
+        }
+    }
+
+    fn add_frames(
+        &mut self,
+        time: u64,
+        pid: u32,
+        tid: u32,
+        frames: &[u64]) {
+        if frames.is_empty() {
+            return;
+        }
+
+        let key = (pid as u64) << 32 | tid as u64;
+
+        let stacks = self.stacks
+            .entry(key)
+            .or_insert_with(|| PartialThreadCallstacks::new(pid, tid));
+
+        if let Some(frames) = stacks.add_frames(
+            time,
+            frames,
+            &mut self.buffer) {
+            let full = CompletedCallstack::new(
+                time,
+                pid,
+                tid,
+                frames);
+
+            full.notify(&mut self.frames_callbacks);
+        }
+    }
+}
+
 pub struct CallstackReader {
     ancillary: ReadOnly<AncillaryData>,
+    lookup: Writable<PartialCallstackLookup>,
     match_id: Writable<u64>,
 }
 
@@ -11,6 +190,7 @@ impl Clone for CallstackReader {
     fn clone(&self) -> Self {
         Self {
             ancillary: self.ancillary.clone(),
+            lookup: self.lookup.clone(),
             match_id: Writable::new(0),
         }
     }
@@ -18,6 +198,18 @@ impl Clone for CallstackReader {
 
 impl CallstackReader {
     pub fn match_id(&self) -> u64 { *self.match_id.borrow() }
+
+    pub fn add_flushed_callback(
+        &self,
+        callback: impl FnMut() + 'static) {
+        self.lookup.borrow_mut().add_flushed_callback(callback);
+    }
+
+    pub fn add_async_frames_callback(
+        &self,
+        callback: impl FnMut(&CompletedCallstack) + 'static) {
+        self.lookup.borrow_mut().add_frames_callback(callback);
+    }
 
     pub fn read_frames(
         &self,
@@ -31,6 +223,8 @@ impl CallstackReader {
 
 pub struct CallstackHelper {
     ancillary: Writable<ReadOnly<AncillaryData>>,
+    lookup: Writable<PartialCallstackLookup>,
+    kernel_callstacks: bool,
 }
 
 impl CallstackHelper {
@@ -40,6 +234,8 @@ impl CallstackHelper {
 
         Self {
             ancillary: Writable::new(empty.read_only()),
+            lookup: Writable::new(PartialCallstackLookup::default()),
+            kernel_callstacks: false,
         }
     }
 
@@ -51,6 +247,7 @@ impl CallstackHelper {
     pub fn to_reader(self) -> CallstackReader {
         CallstackReader {
             ancillary: self.ancillary.borrow().clone(),
+            lookup: self.lookup.clone(),
             match_id: Writable::new(0),
         }
     }
@@ -58,11 +255,245 @@ impl CallstackHelper {
 
 impl CallstackHelp for EtwSession {
     fn with_callstack_help(
-        self,
+        mut self,
         helper: &CallstackHelper) -> Self {
+        let ancillary = self.ancillary_data();
+
         /* Set the ancillary data from the target session */
-        *helper.ancillary.borrow_mut() = self.ancillary_data();
+        *helper.ancillary.borrow_mut() = ancillary.clone();
+
+        let helper_lookup = helper.lookup.clone();
+
+        self.add_built_callback(move |session| {
+            /*
+             * Session is about to be parsed, check if
+             * we should be handling kernel stacks.
+             */
+            if !session.needs_kernel_callstacks() {
+                return Ok(());
+            }
+
+            /* Hookup async callstack event */
+            let callstack = session.callstack_event();
+            let fmt = callstack.format();
+            let time = fmt.get_field_ref_unchecked("EventTimeStamp");
+            let pid = fmt.get_field_ref_unchecked("StackProcess");
+            let tid = fmt.get_field_ref_unchecked("StackThread");
+            let frames = fmt.get_field_ref_unchecked("StackFrames");
+            let frame_offset = fmt.get_field_unchecked(frames).offset;
+
+            let lookup = helper_lookup.clone();
+            let mut frame_buffer = Vec::new();
+
+            /* Callstacks just add to our lookup as they arrive */
+            callstack.add_callback(move |data| {
+                let fmt = data.format();
+                let data = data.event_data();
+
+                let time = fmt.get_u64(time, data)?;
+                let pid = fmt.get_u32(pid, data)?;
+                let tid = fmt.get_u32(tid, data)?;
+
+                /* Read frames from remaining data */
+                let frame_data = &data[frame_offset..];
+
+                frame_buffer.clear();
+
+                for frame in frame_data.chunks_exact(8) {
+                    let frame = unsafe { *(frame.as_ptr() as *const u64) };
+
+                    frame_buffer.push(frame);
+                }
+
+                /* Add frames to lookup */
+                lookup.borrow_mut().add_frames(
+                    time,
+                    pid,
+                    tid,
+                    &frame_buffer);
+
+                Ok(())
+            });
+
+            /* Ensure we flush stacks upon being stopped */
+            let lookup = helper_lookup.clone();
+
+            session.add_stopped_callback(
+                move |_context| {
+                    lookup.borrow_mut().flush();
+                });
+
+            Ok(())
+        });
 
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn build_partial_lookup(
+        time: u64,
+        pid: u32,
+        tid: u32,
+        frames: Vec<u64>,
+        outcome: Writable<bool>) -> PartialCallstackLookup {
+        let mut stacks = PartialCallstackLookup::default();
+
+        stacks.add_frames_callback(move |completed| {
+            *outcome.borrow_mut() =
+                completed.time != time ||
+                completed.pid != pid ||
+                completed.pid != tid ||
+                completed.frames != &frames;
+        });
+
+        stacks
+    }
+
+    #[test]
+    fn partial_callstacks() {
+        let outcome = Writable::new(false);
+
+        let mut stacks = build_partial_lookup(
+            0xf00d,
+            0,
+            1,
+            vec!(KERNEL_START, 0x1, 0x2, 0x3, 0x4),
+            outcome.clone());
+
+        /* Frames ending in userspace should give full callstack */
+        stacks.add_frames(
+            0xf00d,
+            0,
+            1,
+            &vec!(KERNEL_START, 0x1, 0x2, 0x3, 0x4));
+
+        assert_eq!(true, *outcome.borrow());
+        *outcome.borrow_mut() = false;
+
+        /* Partial frames should only complete on user */
+        stacks.add_frames(
+            0xf00d,
+            0,
+            1,
+            &vec!(KERNEL_START));
+        assert_eq!(false, *outcome.borrow());
+
+        stacks.add_frames(
+            0xf00d,
+            0,
+            1,
+            &vec!(0x1, 0x2, 0x3, 0x4));
+        assert_eq!(true, *outcome.borrow());
+        *outcome.borrow_mut() = false;
+
+        /* Flush should work for kernel only stacks */
+        let mut stacks = build_partial_lookup(
+            0xf00d,
+            0,
+            1,
+            vec!(KERNEL_START),
+            outcome.clone());
+
+        stacks.add_frames(
+            0xf00d,
+            0,
+            1,
+            &vec!(KERNEL_START));
+        assert_eq!(false, *outcome.borrow());
+
+        stacks.flush();
+
+        assert_eq!(true, *outcome.borrow());
+    }
+
+    #[test]
+    #[ignore]
+    fn it_works() {
+        let helper = CallstackHelper::new();
+
+        let mut session = EtwSession::new()
+            .with_callstack_help(&helper);
+
+        let ancillary = session.ancillary_data();
+
+        let profile_count = Writable::new(0);
+        let count = profile_count.clone();
+        let event = session.profile_cpu_event(Some(PROPERTY_STACK_TRACE));
+        let profile_times = Writable::new(HashSet::new());
+        let times = profile_times.clone();
+
+        event.add_callback(
+            move |data| {
+                times.borrow_mut().insert(ancillary.borrow().time());
+                *count.borrow_mut() += 1;
+                Ok(())
+            });
+
+        let stack_reader = helper.to_reader();
+
+        let stack_count = Writable::new(0);
+        let count = stack_count.clone();
+        let stack_times = Writable::new(HashSet::new());
+        let times = stack_times.clone();
+
+        stack_reader.add_async_frames_callback(
+            move |stack| {
+                times.borrow_mut().insert(stack.time());
+                *count.borrow_mut() += 1;
+            });
+
+        let flushed_count = Writable::new(0);
+        let count = flushed_count.clone();
+
+        stack_reader.add_flushed_callback(
+            move || {
+                *count.borrow_mut() += 1;
+            });
+
+        let duration = std::time::Duration::from_secs(1);
+
+        session.parse_for_duration(
+            "one_collect_callstacks_test",
+            duration).unwrap();
+
+        let flushed_count = *flushed_count.borrow();
+        let profile_count = *profile_count.borrow();
+        let stack_count = *stack_count.borrow();
+
+        println!("Counts:");
+        println!("Profile: {}", profile_count);
+        println!("Stacks: {}", stack_count);
+
+        let mut first = u64::MAX;
+        let mut last = u64::MIN;
+
+        for time in profile_times.borrow().iter() {
+            let time = *time;
+
+            if time < first {
+                first = time;
+            }
+
+            if time > last {
+                last = time;
+            }
+        }
+
+        for time in profile_times.borrow().iter() {
+            if !stack_times.borrow().contains(time) {
+                println!("Missed {}", time);
+            }
+        }
+
+        println!("Range: {} - {}", first, last);
+
+        assert!(flushed_count != 0);
+        assert!(profile_count != 0);
+        assert!(stack_count != 0);
     }
 }


### PR DESCRIPTION
ETW (and soon Linux) supports async callstack collection when a callstack originates in the kernel. An example of this is the SampledProfile event (1), if the sample is on a CPU that is running in kernel mode, the kernel callstack is emitted after the SampledProfile event as a StackWalk event (2). The tricky part, is if the process also has user-mode code that lead up to the kernel call (very likely) then yet another StackWalk event (2) is emitted. We don't want every event to know this detail or handle if user callstacks fail or never come in.

To ensure this is done consistently, add mechanisms to register when a full async callstack has been read (add_async_frames_callback) to the Windows CallstackReader struct. For cases when a user callstack never comes in, expose add_flushed_callback to the Windows CallstackReader struct as well.

Expose a built_callback in EtwSession to ensure the CallstackHelper can run a closure to see if kernel callstacks are enabled for anything. If they are, then hookup the CallstackHelper to the EtwSession, utilizing these newly exposed callbacks correctly.

Add self tests to ensure the lookup works correctly for all cases.

NOTE:
The Linux SFrame work (3) will likely also need a similar pattern, although the way to lookup matches will be different. When that occurs I expect the add_async_frames_callback and add_flushed_callback to be in both OS modules.

1. https://learn.microsoft.com/en-us/windows/win32/etw/sampledprofile
2. https://learn.microsoft.com/en-us/windows/win32/etw/stackwalk-event
3. https://lwn.net/Articles/932209/