### PR TITLE
Harden DupFd Implementation and Usage

### DIFF
--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -138,7 +138,7 @@ impl ExportDevNodeLookup {
         &self,
         node: &ExportDevNode) -> Option<File> {
         match self.fds.get(node) {
-            Some(fd) => { Some(fd.open()) },
+            Some(fd) => { fd.open() },
             None => { None },
         }
     }

--- a/one_collect/src/helpers/exporting/process.rs
+++ b/one_collect/src/helpers/exporting/process.rs
@@ -137,9 +137,9 @@ impl ExportProcess {
         path_buf.push("root");
         path_buf.push(".");
 
-        let root = File::open(path_buf)?;
-
-        self.root_fs = Some(OpenAt::new(root));
+        if let Ok(root) = File::open(path_buf) {
+            self.root_fs = Some(OpenAt::new(root));
+        }
 
         Ok(())
     }

--- a/one_collect/src/openat.rs
+++ b/one_collect/src/openat.rs
@@ -33,11 +33,15 @@ impl DupFd {
     /// has its own separate file descriptor that can be used independently of others.
     ///
     /// # Returns
-    /// * `File`: The new `File` that was opened.
-    pub fn open(&self) -> File {
+    /// * `Option<File>`: The new `File` that was opened or None if call to dup failed.
+    pub fn open(&self) -> Option<File> {
         unsafe {
             let cloned_fd = libc::dup(self.fd);
-            File::from_raw_fd(cloned_fd)
+            if cloned_fd != -1 {
+                return Some(File::from_raw_fd(cloned_fd));
+            }
+
+            None
         }
     }
 }


### PR DESCRIPTION
Transient processes that terminate during tracing can result in files disappearing out from underneath the profiler.  This occurs because we access files through /proc/<pid>/root, which will disappear as soon as the process is terminated.

This is addressed in two ways:
1. If /proc/<pid>/root no longer exists by the time we process the comm event, do not add the root_fs.
2. At export time when tracing is complete, if a call to dup in DupFd fails, then return None instead of attempting to create the new Fd, which will result in a panic.