### PR TITLE
Exporting: Make ExportSettings explicit

### DIFF
--- a/one_collect/examples/perf_export.rs
+++ b/one_collect/examples/perf_export.rs
@@ -17,7 +17,7 @@ fn main() {
     let duration = std::time::Duration::from_secs(5);
 
     let settings = ExportSettings::default()
-        .without_cswitches();
+        .with_cpu_profiling(1000);
 
     let mut dotnet = UniversalDotNetHelper::default()
         .with_dynamic_symbols();

--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -262,9 +262,9 @@ impl ExportSettings {
         Self {
             string_buckets: 64,
             callstack_buckets: 512,
-            cpu_profiling: true,
+            cpu_profiling: false,
             cpu_freq: 1000,
-            cswitches: true,
+            cswitches: false,
             callstack_helper: Some(callstack_helper.with_external_lookup()),
             unwinder,
             #[cfg(target_os = "linux")]
@@ -304,10 +304,11 @@ impl ExportSettings {
         clone
     }
 
-    pub fn with_cpu_profile_freq(
+    pub fn with_cpu_profiling(
         self,
         freq: u64) -> Self {
         let mut clone = self;
+        clone.cpu_profiling = true;
         clone.cpu_freq = freq;
         clone
     }
@@ -320,15 +321,9 @@ impl ExportSettings {
         clone
     }
 
-    pub fn without_cswitches(self) -> Self {
+    pub fn with_cswitches(self) -> Self {
         let mut clone = self;
-        clone.cswitches = false;
-        clone
-    }
-
-    pub fn without_cpu_profiling(self) -> Self {
-        let mut clone = self;
-        clone.cpu_profiling = false;
+        clone.cswitches = true;
         clone
     }
 }

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -1212,7 +1212,9 @@ mod tests {
         let helper = CallstackHelper::new()
             .with_dwarf_unwinding();
 
-        let mut settings = ExportSettings::new(helper);
+        let mut settings = ExportSettings::new(helper)
+            .with_cpu_profiling(1000)
+            .with_cswitches();
 
         /* Hookup page_fault as a new event sample */
         let tracefs = TraceFS::open().unwrap();

--- a/one_collect/src/helpers/exporting/os/windows.rs
+++ b/one_collect/src/helpers/exporting/os/windows.rs
@@ -645,7 +645,9 @@ mod tests {
         let mut session = EtwSession::new()
             .with_callstack_help(&helper);
 
-        let settings = ExportSettings::new(helper);
+        let settings = ExportSettings::new(helper)
+            .with_cpu_profiling(1000)
+            .with_cswitches();
 
         let exporter = session.build_exporter(settings).unwrap();
 


### PR DESCRIPTION
Today the ExportSettings default is to enable cpu profiling and context switches. This can be confusing and make files larger than needed when just cpu profiling is required, or just context switches, or even just specific events.

Have cpu_profiling and cswitches disabled by default.

Swap without_* methods for with_* methods.

Tie together CPU frequency and enablement, so frequency is always clearly stated without any assumptions.

Closes #90 