### PR TITLE
Event: Move to unified OS documentation

### DIFF
--- a/one_collect/src/etw/abi.rs
+++ b/one_collect/src/etw/abi.rs
@@ -1,4 +1,9 @@
-use std::os::windows::io::RawHandle;
+/*
+ * std::os::windows::RawHandle is not available when
+ * documenting windows code on non-windows builds.
+ * Use the common definition to allow for this.
+ */
+type RawHandle = *mut std::os::raw::c_void;
 
 use super::*;
 

--- a/one_collect/src/event/mod.rs
+++ b/one_collect/src/event/mod.rs
@@ -1,8 +1,6 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
-#[cfg_attr(target_os = "linux", path = "os/linux.rs")]
-#[cfg_attr(target_os = "windows", path = "os/windows.rs")]
 pub mod os;
 
 pub type EventExtension = os::EventExtension;

--- a/one_collect/src/event/os/mod.rs
+++ b/one_collect/src/event/os/mod.rs
@@ -1,0 +1,13 @@
+/* Windows */
+#[cfg(any(doc, target_os = "windows"))]
+pub mod windows;
+
+#[cfg(target_os = "windows")]
+pub type EventExtension = windows::EventExtension;
+
+/* Linux */
+#[cfg(any(doc, target_os = "linux"))]
+pub mod linux;
+
+#[cfg(target_os = "linux")]
+pub type EventExtension = linux::EventExtension;

--- a/one_collect/src/event/os/windows.rs
+++ b/one_collect/src/event/os/windows.rs
@@ -1,3 +1,4 @@
+use crate::event::Event;
 use crate::etw::Guid;
 
 #[derive(Default)]
@@ -23,4 +24,31 @@ impl EventExtension {
     pub fn keyword(&self) -> u64 { self.keyword }
 
     pub fn keyword_mut(&mut self) -> &mut u64 { &mut self.keyword }
+}
+
+pub trait WindowsEventExtension {
+    fn for_etw(
+        id: usize,
+        name: String,
+        provider: Guid,
+        level: u8,
+        keyword: u64) -> Event;
+}
+
+impl WindowsEventExtension for Event {
+    fn for_etw(
+        id: usize,
+        name: String,
+        provider: Guid,
+        level: u8,
+        keyword: u64) -> Event {
+        let mut event = Event::new(id, name);
+        let ext = event.extension_mut();
+
+        *ext.provider_mut() = provider;
+        *ext.level_mut() = level;
+        *ext.keyword_mut() = keyword;
+
+        event
+    }
 }

--- a/one_collect/src/lib.rs
+++ b/one_collect/src/lib.rs
@@ -12,7 +12,7 @@ pub mod perf_event;
 #[cfg(target_os = "linux")]
 pub mod openat;
 
-#[cfg(target_os = "windows")]
+#[cfg(any(doc, target_os = "windows"))]
 pub mod etw;
 
 pub use sharing::{Writable, ReadOnly};


### PR DESCRIPTION
We need to ensure that documentation can be done for all of our code regardless of the supported OS it is built on. We also want to have a consistent way to define an OS extension, but have it be documented without changing the structures.

Move Event toward a extension trait that is per-OS to ensure they can be compiled anywhere it is supported and still have full documentation.

This is the first change to see how we feel about how this looks. It's a little tricky to ensure minimal #cfg statements while allowing for cross-platform documentation. I'll be going through and ensuring everywhere we have a #cfg statement it also builds when doc is specified. This ensures all our code is properly documented for all builds and will push us more toward a internal OS object that is then accessed in per-OS modules via extension traits (using that internal OS object in the implementation).