### PR TITLE
Unify OS documentation

### DIFF
--- a/one_collect/src/lib.rs
+++ b/one_collect/src/lib.rs
@@ -3,13 +3,13 @@ pub mod sharing;
 pub mod helpers;
 pub mod intern;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(doc, target_os = "linux"))]
 pub mod tracefs;
-#[cfg(target_os = "linux")]
+#[cfg(any(doc, target_os = "linux"))]
 pub mod procfs;
-#[cfg(target_os = "linux")]
+#[cfg(any(doc, target_os = "linux"))]
 pub mod perf_event;
-#[cfg(target_os = "linux")]
+#[cfg(any(doc, target_os = "linux"))]
 pub mod openat;
 
 #[cfg(any(doc, target_os = "windows"))]

--- a/one_collect/src/openat.rs
+++ b/one_collect/src/openat.rs
@@ -1,8 +1,15 @@
 use std::fs::File;
 use std::ffi::CString;
 use std::path::Path;
+
+#[cfg(target_os = "linux")]
 use std::os::unix::ffi::OsStrExt;
+#[cfg(target_os = "linux")]
 use std::os::fd::{RawFd, FromRawFd, IntoRawFd};
+
+/* Required for cross-platform docs */
+#[cfg(not(target_os = "linux"))]
+struct RawFd {}
 
 /// `DupFd` is a wrapper around a raw file descriptor.
 ///

--- a/one_collect/src/perf_event/bpf.rs
+++ b/one_collect/src/perf_event/bpf.rs
@@ -1,5 +1,6 @@
 use std::mem::size_of;
 
+#[cfg(target_os = "linux")]
 use libc::*;
 use super::*;
 

--- a/one_collect/src/perf_event/mod.rs
+++ b/one_collect/src/perf_event/mod.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::os::fd::FromRawFd;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::array::TryFromSliceError;
@@ -10,6 +9,9 @@ use super::*;
 use crate::sharing::*;
 use crate::event::*;
 use crate::PathBufInteger;
+
+#[cfg(target_os = "linux")]
+use std::os::fd::FromRawFd;
 
 pub mod abi;
 pub mod rb;

--- a/one_collect/src/perf_event/rb/mod.rs
+++ b/one_collect/src/perf_event/rb/mod.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 use std::arch::asm;
 use std::rc::Rc;
 
+#[cfg(target_os = "linux")]
 use libc::*;
 
 use super::abi;

--- a/one_collect/src/tracefs.rs
+++ b/one_collect/src/tracefs.rs
@@ -245,8 +245,10 @@ impl TraceFS {
     /// # Example
     ///
     /// ```
+    /// # #[cfg(target_os = "linux")]
     /// use one_collect::tracefs::TraceFS;
     ///
+    /// # #[cfg(target_os = "linux")]
     /// if let Ok(tracefs) = TraceFS::open() {
     ///     let event = tracefs.find_event("sched", "sched_waking");
     /// }


### PR DESCRIPTION
We need to be able to build documentation on all OS's we support. There are a few root level cfg's per-OS that need to get fixed.

Have openat, perf_event, and tracefs build when doc is defined, regardless of OS. Fix up namespaces that are per-OS enough to make the doc generation happy.

Next set of changes will be focusing on getting everything under OS extension traits vs defining things directly, following std's direction.