### PR TITLE
Exporting: Move ExportProcess to OS trait extension

### DIFF
--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -344,7 +344,7 @@ pub struct ExportMachine {
     settings: ExportSettings,
     strings: InternedStrings,
     callstacks: InternedCallstacks,
-    os: OSExportMachine,
+    pub(crate) os: OSExportMachine,
     procs: HashMap<u32, ExportProcess>,
     module_metadata: ModuleMetadataLookup,
     cswitches: HashMap<u32, ExportCSwitch>,


### PR DESCRIPTION
The ExportProcess is used both on Windows and Linux, each has it's own data it needs to store and different operations to open files, etc.

Move the ExportProcess struct to our established OS trait extension model. Only have truly common operations, such as open_file(), into the OS trait extension. Keep ns_pid logic separate, since each OS needs to dynamically fetch this data very differently.

Fixes minor warnings as well in the adapted code sections while it is being changed.