### PR TITLE
Exporting: Move ExportSettings to OS trait extension

### DIFF
--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -13,13 +13,14 @@ use pe_file::PEModuleMetadata;
 
 mod lookup;
 
-#[cfg_attr(target_os = "linux", path = "os/linux.rs")]
-#[cfg_attr(target_os = "windows", path = "os/windows.rs")]
 pub mod os;
 use os::OSExportMachine;
 use os::OSExportSampler;
+use os::OSExportSettings;
 
-pub type OSExportSettings = os::OSExportSettings;
+/* Make it easy for callers to use public OS extensions */
+#[cfg(target_os = "linux")]
+pub use os::linux::ExportSettingsLinuxExt;
 
 pub const KERNEL_START:u64 = 0xFFFF800000000000;
 pub const KERNEL_END:u64 = 0xFFFFFFFFFFFFFFFF;
@@ -319,10 +320,6 @@ impl ExportSettings {
             events: None,
         }
     }
-
-    pub fn os_settings(&self) -> &OSExportSettings { &self.os }
-
-    pub fn os_settings_mut(&mut self) -> &mut OSExportSettings { &mut self.os }
 
     pub fn has_unwinder(&self) -> bool { self.unwinder }
 

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -1,4 +1,3 @@
-use super::*;
 use std::collections::hash_map::Entry;
 use std::collections::hash_map::Entry::{Vacant, Occupied};
 use std::path::{Path, PathBuf};
@@ -16,6 +15,7 @@ use crate::perf_event::{AncillaryData, PerfSession};
 use crate::perf_event::{RingBufSessionBuilder, RingBufBuilder};
 use crate::perf_event::abi::PERF_RECORD_MISC_SWITCH_OUT;
 use crate::helpers::callstack::CallstackHelp;
+use crate::helpers::exporting::*;
 use crate::helpers::exporting::process::ExportProcessOSHooks;
 use crate::helpers::exporting::modulemetadata::{ModuleMetadata, ElfModuleMetadata};
 
@@ -424,6 +424,7 @@ impl ExportProcessLinuxExt for ExportProcess {
     }
 }
 
+#[cfg(target_os = "linux")]
 impl ExportProcessOSHooks for ExportProcess {
     fn os_open_file(
         &self,
@@ -458,7 +459,7 @@ pub(crate) fn default_export_settings() -> ExportSettings {
         ExportSettings::new(helper)
 }
 
-pub struct OSExportSettings {
+pub(crate) struct OSExportSettings {
     process_fs: bool,
 }
 
@@ -470,8 +471,12 @@ impl OSExportSettings {
     }
 }
 
-impl ExportSettings {
-    pub fn without_process_fs(self) -> Self {
+pub trait ExportSettingsLinuxExt {
+    fn without_process_fs(self) -> Self;
+}
+
+impl ExportSettingsLinuxExt for ExportSettings {
+    fn without_process_fs(self) -> Self {
         let mut clone = self;
         clone.os.process_fs = false;
         clone
@@ -500,6 +505,7 @@ impl OSExportSampler {
     }
 }
 
+#[cfg(target_os = "linux")]
 impl ExportSamplerOSHooks for ExportSampler {
     fn os_event_time(
         &self,
@@ -1043,6 +1049,7 @@ impl ModuleAccessor for ExportDevNodeLookup {
     }
 }
 
+#[cfg(target_os = "linux")]
 impl ExportMachineOSHooks for ExportMachine {
     fn os_add_kernel_mappings_with(
         &mut self,

--- a/one_collect/src/helpers/exporting/os/mod.rs
+++ b/one_collect/src/helpers/exporting/os/mod.rs
@@ -1,0 +1,13 @@
+/* Windows */
+#[cfg(any(doc, target_os = "windows"))]
+pub mod windows;
+
+#[cfg(target_os = "windows")]
+pub use windows::*;
+
+/* Linux */
+#[cfg(any(doc, target_os = "linux"))]
+pub mod linux;
+
+#[cfg(target_os = "linux")]
+pub use linux::*;

--- a/one_collect/src/helpers/exporting/os/windows.rs
+++ b/one_collect/src/helpers/exporting/os/windows.rs
@@ -2,9 +2,9 @@ use std::collections::hash_map::Entry::Occupied;
 
 use std::fs::File;
 
-use super::*;
 use crate::{ReadOnly, Writable};
 use crate::etw::*;
+use crate::helpers::exporting::*;
 use crate::helpers::exporting::process::ExportProcessOSHooks;
 
 /* OS Specific Session Type */
@@ -36,7 +36,7 @@ impl PushWide for String {
     }
 }
 
-pub struct OSExportSettings {
+pub(crate) struct OSExportSettings {
     /* Placeholder */
 }
 
@@ -59,6 +59,7 @@ impl OSExportProcess {
     }
 }
 
+#[cfg(target_os = "windows")]
 impl ExportProcessOSHooks for ExportProcess {
     fn os_open_file(
         &self,
@@ -81,6 +82,7 @@ impl OSExportSampler {
     }
 }
 
+#[cfg(target_os = "windows")]
 impl ExportSamplerOSHooks for ExportSampler {
     fn os_event_time(
         &self,
@@ -555,6 +557,7 @@ impl OSExportMachine {
     }
 }
 
+#[cfg(target_os = "windows")]
 impl ExportMachineOSHooks for ExportMachine {
     fn os_add_kernel_mappings_with(
         &mut self,


### PR DESCRIPTION
The ExportSettings is used both on Windows and Linux, each has it's own data it needs to store for OS setup decisions.

Move the ExportSettings struct to our established OS trait extension model.

Setup pattern for per-OS settings, as the ExportSettingsLinuxExt trait for process_fs settings. Windows doesn't need this yet, but when it does it will define and implement an ExportSettingsWindowsExt. This is consistent naming with our ExportProcessLinuxExt and ExportProcessWindowsExt traits.

Split out OS into a mod.rs, windows.rs, and linux.rs files. The mod.rs setups up documenting both sides equally. Only the compiling part gets a pub use for the rest of the crate.