### PR TITLE
Exporting: Move UniversalExporter to OS trait extension

### DIFF
--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -6,7 +6,7 @@ use crate::Writable;
 use crate::event::{Event, EventData};
 use crate::intern::{InternedStrings, InternedCallstacks};
 
-use crate::helpers::callstack::{CallstackHelper, CallstackReader};
+use crate::helpers::callstack::CallstackHelper;
 
 use modulemetadata::ModuleMetadata;
 use pe_file::PEModuleMetadata;


### PR DESCRIPTION
The UniversalExporter only has public methods that work on all OS's we support. However, internally, it needs to handle per-OS differences.

Move the UniversalExporter struct to our established OS trait extension model.

Have each OS implement how to create and setup a session and parse until the closure invocation returns true.