### PR TITLE
Fix File Metadata Capture

### DIFF
--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -515,7 +515,7 @@ impl ExportMachine {
     }
 
     pub fn capture_file_symbol_metadata(&mut self) {
-        self.os_resolve_local_file_symbols();
+        self.os_capture_file_symbol_metadata();
     }
 
     pub fn resolve_local_file_symbols(&mut self) {


### PR DESCRIPTION
Post refactor, file metadata isn't captured during export, which means that no file-backed maps get their symbols resolved.