### PR TITLE
Exporting: Add replay_by_time() / ExportProcessReplay

### DIFF
--- a/one_collect/src/helpers/exporting/mappings.rs
+++ b/one_collect/src/helpers/exporting/mappings.rs
@@ -264,6 +264,10 @@ impl ExportMappingLookup {
         &mut self.mappings
     }
 
+    pub fn sort_mappings_by_time(&mut self) {
+        self.mappings_mut().sort_by(|a, b| a.time.cmp(&b.time));
+    }
+
     pub fn mappings(&self) -> &Vec<ExportMapping> { &self.mappings }
 
     fn build_lookup(&self) {


### PR DESCRIPTION
Some formats require perfect time ordering, where each event across the entire machine should be played back in ascending order in terms of time. This is a fairly hard problem to solve and we do not want each format owner to have to deal with this, if it's required for the format.

Add replay_by_time() to ExportMachine which takes a predicate and a callback for the event that occurred. Callers can scope replay to a set of processes this way.

Add ExportProcessReplay struct which is used to manage the playback internally, but also describe what event occurred externally (pub). Callbacks ask the ExportProcessReplay for details, like if this is a sample, mapping, create, exit event. It also describes the time and process that the event came from. This also allows for multiple events that happened at the same exact time (cornercase, unlikely but possible) within a single process.

Add extensive tests to ensure weird corner cases are handled.