### PR TITLE
Exporting: Add os attributes and errors for replay

### DIFF
--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -378,6 +378,8 @@ impl ExportSettings {
         clone.cswitches = true;
         clone
     }
+
+    pub fn cpu_freq(&self) -> u64 { self.cpu_freq }
 }
 
 pub struct ExportMachine {
@@ -425,6 +427,8 @@ pub trait ExportMachineOSHooks {
     fn os_qpc_time(&self) -> u64;
 
     fn os_qpc_freq(&self) -> u64;
+
+    fn os_cpu_count(&self) -> u32;
 }
 
 pub type CommMap = HashMap<Option<usize>, Vec<u32>>;
@@ -458,12 +462,19 @@ impl ExportMachine {
 
     pub fn duration(&self) -> Option<Duration> { self.duration }
 
+    pub fn settings(&self) -> &ExportSettings { &self.settings }
+
+    pub fn qpc_freq(&self) -> u64 { self.os_qpc_freq() }
+
+    pub fn cpu_count(&self) -> u32 { self.os_cpu_count() }
+
     pub fn replay_by_time(
         &mut self,
         predicate: impl Fn(&ExportProcess) -> bool,
-        mut callback: impl FnMut(&ExportProcessReplay)) {
+        mut callback: impl FnMut(&ExportMachine, &ExportProcessReplay) -> anyhow::Result<()>) -> anyhow::Result<()> {
         let mut replay_procs = Vec::new();
 
+        /* Need to do sorting as mut */
         for process in self.processes_mut() {
             if !predicate(process) {
                 continue;
@@ -472,6 +483,13 @@ impl ExportMachine {
             /* Sort */
             process.sort_samples_by_time();
             process.sort_mappings_by_time();
+        }
+
+        /* Replays are immutable refs */
+        for process in self.processes() {
+            if !predicate(process) {
+                continue;
+            }
 
             /* Allocate details for replaying */
             replay_procs.push(process.to_replay());
@@ -505,12 +523,14 @@ impl ExportMachine {
                 }
 
                 if replay.time() == earliest {
-                    (callback)(replay);
+                    (callback)(&self, replay)?;
 
                     replay.advance();
                 }
             }
         }
+
+        Ok(())
     }
 
     pub fn mark_start(&mut self) {
@@ -862,7 +882,7 @@ mod tests {
 
         machine.replay_by_time(
             |_process| true,
-            |event| {
+            |_machine, event| {
                 if event.time() % 2 == 0 {
                     assert_eq!(2, event.process().pid());
                 } else {
@@ -872,6 +892,8 @@ mod tests {
                 assert_eq!(event.time() - 1, time);
 
                 time = event.time();
-            });
+
+                Ok(())
+            }).expect("Should work");
     }
 }

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -1330,6 +1330,12 @@ impl ExportMachineOSHooks for ExportMachine {
 
         (1000000000 / t.tv_nsec) as u64
     }
+
+    fn os_cpu_count(&self) -> u32 {
+        unsafe {
+            libc::sysconf(libc::_SC_NPROCESSORS_ONLN) as u32
+        }
+    }
 }
 
 impl ExportBuilderHelp for RingBufSessionBuilder {

--- a/one_collect/src/helpers/exporting/os/windows.rs
+++ b/one_collect/src/helpers/exporting/os/windows.rs
@@ -686,6 +686,9 @@ extern "system" {
 
     fn QueryPerformanceFrequency(
         freq: *mut u64) -> u32;
+
+    fn GetActiveProcessorCount(
+        group: u16) -> u32;
 }
 
 #[cfg(target_os = "windows")]
@@ -790,6 +793,12 @@ impl ExportMachineOSHooks for ExportMachine {
         }
 
         t
+    }
+
+    fn os_cpu_count(&self) -> u32 {
+        unsafe {
+            GetActiveProcessorCount(0xFFFF)
+        }
     }
 }
 


### PR DESCRIPTION
Formats need to be able to access the qpc frequency and CPU sampling frequency both in and out of tree. We need to enable public methods for accessing these.

Formats also need to have immutable access to the ExportMachine, however, during replay we have a mutable reference. We need to break this out for callers.

Add public accessors for ExportSettings, os_cpu_count, and os_qpc_freq to ExportMachine.

Change the replay_by_time callback to include an immutable reference to the ExportMachine to allow kind and string lookups.