### PR TITLE
Emit NetTrace Files from Record-Trace

### DIFF
--- a/record-trace/Cargo.toml
+++ b/record-trace/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.75"
 clap = { version = "4.5.26", features = ["cargo", "derive"] }
 ctrlc = "3.2"
 one_collect = { path = "../one_collect" }

--- a/record-trace/src/commandline.rs
+++ b/record-trace/src/commandline.rs
@@ -55,19 +55,7 @@ impl RecordArgs {
         
         // If --out isn't specified, default to the current working directory.
         let output_path = match command_args.out {
-            Some(path) => {
-                let path = PathBuf::from(path);
-                if path.exists() && !path.is_dir() {
-                    eprintln!("{} is not a directory.", path.display());
-                    process::exit(1);
-                }
-                else if !path.exists() {
-                    eprintln!("{} does not exist.", path.display());
-                    process::exit(1);
-                }
-
-                path
-            },
+            Some(path) => { PathBuf::from(path) },
             None => {
                 match env::current_dir() {
                     Ok(current_dir) => current_dir,
@@ -85,7 +73,7 @@ impl RecordArgs {
         };
 
         // Cross-argument validation.
-        if !args.on_cpu {
+        if !args.on_cpu && !args.off_cpu {
             eprintln!("No events selected. Exiting.");
             process::exit(1);
         }

--- a/record-trace/src/export.rs
+++ b/record-trace/src/export.rs
@@ -4,12 +4,18 @@ use one_collect::helpers::exporting::formats::perf_view::*;
 use one_collect::helpers::exporting::graph::ExportGraph;
 
 use crate::commandline::RecordArgs;
+use anyhow::anyhow;
+use std::path::PathBuf;
 
 pub (crate) trait Exporter {
+    fn validate(
+        &mut self,
+        args: &RecordArgs) -> anyhow::Result<()>;
+
     fn run(
         &self,
         machine: &mut ExportMachine,
-        args: &RecordArgs) -> bool;
+        args: &RecordArgs) -> anyhow::Result<()>;
 }
 
 pub (crate) struct PerfViewExporter {
@@ -23,15 +29,49 @@ impl PerfViewExporter {
 }
 
 impl Exporter for PerfViewExporter {
+    fn validate(
+        &mut self,
+        args: &RecordArgs) -> anyhow::Result<()> {
+        let output_path = args.output_path();
+        if output_path.exists() && !output_path.is_dir() {
+            return Err(anyhow!("{} is not a directory.", output_path.display()));
+        }
+        else if !output_path.exists() {
+            return Err(anyhow!("{} does not exist.", output_path.display()));
+        }
+
+        Ok(())
+    }
+
     fn run(
         &self,
         machine: &mut ExportMachine,
-        args: &RecordArgs) -> bool {
+        args: &RecordArgs) -> anyhow::Result<()> {
+
         /* Split by comm name */
         let comm_map = machine.split_processes_by_comm();
 
-        let cpu = machine.find_sample_kind("cpu").expect("CPU sample kind should be known.");
-        let cswitch = machine.find_sample_kind("cswitch").expect("CSwitch sample kind should be known.");
+        let cpu = match machine.find_sample_kind("cpu") {
+            Some(cpu) => { cpu },
+            None => {
+                if args.on_cpu() {
+                    return Err(anyhow!("CPU sample kind should be known."));
+                }
+
+                0
+            }
+        };
+
+        let cswitch = match machine.find_sample_kind("cswitch") {
+            Some(cswitch) => { cswitch },
+            None => {
+                if args.off_cpu() {
+                    return Err(anyhow!("CSwitch sample kind should be known."));
+                }
+
+                0
+            }
+        };
 
         let mut graph = ExportGraph::new();
         let mut buf: String;
@@ -42,25 +82,29 @@ impl Exporter for PerfViewExporter {
                     for pid in pids {
                         let single_pid = vec![pid];
 
-                        let path = format!("{}/t.Unknown.{}.CPU.PerfView.xml", args.output_path().display(), pid);
+                        if args.on_cpu() {
+                            let path = format!("{}/t.Unknown.{}.CPU.PerfView.xml", args.output_path().display(), pid);
 
-                        Self::export_pids(
-                            machine,
-                            &mut graph,
-                            &single_pid,
-                            cpu,
-                            &path,
-                            "CPU Samples");
+                            Self::export_pids(
+                                machine,
+                                &mut graph,
+                                &single_pid,
+                                cpu,
+                                &path,
+                                "CPU Samples");
+                        }
 
-                        let path = format!("{}/t.Unknown.{}.CSwitch.PerfView.xml", args.output_path().display(), pid);
+                        if args.off_cpu() {
+                            let path = format!("{}/t.Unknown.{}.CSwitch.PerfView.xml", args.output_path().display(), pid);
 
-                        Self::export_pids(
-                            machine,
-                            &mut graph,
-                            &single_pid,
-                            cswitch,
-                            &path,
-                            "Wait Time");
+                            Self::export_pids(
+                                machine,
+                                &mut graph,
+                                &single_pid,
+                                cswitch,
+                                &path,
+                                "Wait Time");
+                        }
                     }
                 },
                 Some(comm_id) => {
@@ -77,29 +121,33 @@ impl Exporter for PerfViewExporter {
                         Err(_) => { "Unknown" },
                     };
 
-                    let path = format!("{}/t.{}.CPU.PerfView.xml", args.output_path().display(), comm);
+                    if args.on_cpu() {
+                        let path = format!("{}/t.{}.CPU.PerfView.xml", args.output_path().display(), comm);
 
-                    Self::export_pids(
-                        machine,
-                        &mut graph,
-                        &pids,
-                        cpu,
-                        &path,
-                        "CPU Samples");
+                        Self::export_pids(
+                            machine,
+                            &mut graph,
+                            &pids,
+                            cpu,
+                            &path,
+                            "CPU Samples");
+                    }
 
-                    let path = format!("{}/t.{}.CSwitch.PerfView.xml", args.output_path().display(), comm);
+                    if args.off_cpu() {
+                        let path = format!("{}/t.{}.CSwitch.PerfView.xml", args.output_path().display(), comm);
 
-                    Self::export_pids(
-                        machine,
-                        &mut graph,
-                        &pids,
-                        cswitch,
-                        &path,
-                        "Wait Time");
+                        Self::export_pids(
+                            machine,
+                            &mut graph,
+                            &pids,
+                            cswitch,
+                            &path,
+                            "Wait Time");
+                    }
                 }
             }
         }
-    true
+        Ok(())
     }
 }
 
@@ -133,24 +181,45 @@ impl PerfViewExporter {
 }
 
 pub (crate) struct NetTraceExporter {
+    output_path: PathBuf,
 }
 
 impl NetTraceExporter {
     pub fn new() -> Self {
         Self {
+            output_path: PathBuf::new(),
         }
     }
 }
 
 impl Exporter for NetTraceExporter {
+    fn validate(
+        &mut self,
+        args: &RecordArgs) -> anyhow::Result<()> {
+        let output_path = args.output_path();
+        self.output_path.push(args.output_path());
+
+        if output_path.exists() && output_path.is_dir() {
+            if let Some(extension) = output_path.extension() {
+                if extension == "nettrace" {
+                    return Err(anyhow!("{} is a directory.", output_path.display()));
+                }
+            }
+            else {
+                self.output_path.push("trace.nettrace");
+            }
+        }
+
+        Ok(())
+    }
+
     fn run(
         &self,
         machine: &mut ExportMachine,
-        args: &RecordArgs) -> bool {
+        _args: &RecordArgs) -> anyhow::Result<()> {
 
-        let path = format!("{}/trace.nettrace", args.output_path().display());
-        let _ = machine.to_net_trace(|_proc| { true }, &path);
+        let _ = machine.to_net_trace(|_proc| { true }, &self.output_path.to_str().unwrap());
 
-    true
+        Ok(())
     }
 }

--- a/record-trace/src/recorder.rs
+++ b/record-trace/src/recorder.rs
@@ -21,6 +21,12 @@ impl Recorder {
     }
 
     pub (crate) fn run(&mut self) {
+        let mut format = self.args.format();
+        if let Err(e) = format.validate(&self.args) {
+            eprintln!("Error: {}", e);
+            process::exit(1);
+        }
+
         let mut settings = ExportSettings::default();
 
         // CPU sampling.
@@ -84,7 +90,10 @@ impl Recorder {
         println!("Resolving symbols.");
         exporter.capture_and_resolve_symbols();
 
-        self.args.format().run(&mut exporter, &self.args);
+        if let Err(e) = format.run(&mut exporter, &self.args) {
+            eprintln!("Error: {}", e);
+            process::exit(1);
+        }
 
         println!("Finished recording trace.");
         println!("Trace written to {}", self.args.output_path().display());


### PR DESCRIPTION
 - Add a new implementation of `Exporter` for nettrace files.
 - Clean-up the exporter implementation to use anyhow for errors and allow for validation of command line arguments prior to capture.