### PR TITLE
Add the text section VA offset to serialized PE metadata.

### DIFF
--- a/one_collect/src/helpers/exporting/pe_file.rs
+++ b/one_collect/src/helpers/exporting/pe_file.rs
@@ -77,6 +77,8 @@ impl PEModuleMetadata {
             out.push_str("\",");
         }
 
+        out.push_str(&format!("\"text_offset\": {},", self.text_loaded_layout_offset));
+
         /* Remove trailing comma if it exists */
         if out.ends_with(',') {
             out.pop();
@@ -847,6 +849,7 @@ mod tests {
         m.perfmap_sig = [4; 16];
         m.perfmap_version = 5;
         m.perfmap_name_id = strings.to_id("perfmap_name");
+        m.text_loaded_layout_offset = 65516;
 
         let mut out = String::new();
 
@@ -862,7 +865,8 @@ mod tests {
         expected.push_str("\"signature\": \"03030303030303030303030303030303\",");
         expected.push_str("\"perfmap_signature\": \"04040404040404040404040404040404\",");
         expected.push_str("\"perfmap_version\": 5,");
-        expected.push_str("\"perfmap_name\": \"perfmap_name\"");
+        expected.push_str("\"perfmap_name\": \"perfmap_name\",");
+        expected.push_str("\"text_offset\": 65516");
         expected.push_str("}");
 
         assert_eq!(expected, out);


### PR DESCRIPTION
This is required to calculate RVAs when doing remote symbol lookup for .NET ready to run images for processes running on Linux. CoreCLR load behavior results in a single mapping being reported for the text section, but RVAs must be calculated from the ImageBase virtual address. The offset is used to translate from the text section virtual address to the ImageBase virtual address and then from IP to RVA.

   RVA = IP - ExecutableMappingStartVA - text_offset

This can change if CoreCLR changes its load behavior. I intend to look at adding tests to the dotnet/runtime repo to catch if this behavior changes.