### PR TITLE
BUG: Fix DotNet IPC Event IDs

### DIFF
--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -148,7 +148,7 @@ impl PerfMapContext {
 
 struct UserEventTracepointEvents {
     tracepoint: String,
-    events: Vec<u16>,
+    events: Vec<u32>,
 }
 
 #[derive(Default)]
@@ -178,7 +178,7 @@ impl UserEventProviderEvents {
         let mut events = Vec::new();
 
         for event in dotnet_events {
-            events.push(*event as u16);
+            events.push(*event as u32);
         }
 
         self.keyword |= keyword;
@@ -587,7 +587,7 @@ struct LinuxDotNetEvent {
     level: u8,
 }
 
-const DOTNET_HEADER_FIELDS: &str = "u16 event_id; __rel_loc u8[] payload; __rel_loc u8[] meta";
+const DOTNET_HEADER_FIELDS: &str = "u8 version; u16 event_id; __rel_loc u8[] extension; __rel_loc u8[] payload; __rel_loc u8[] meta";
 
 struct DotNetEventDesc {
     name: String,


### PR DESCRIPTION
Event IDs should be 32-bit on the wire, and not 16-bit.

Change events from u16 to u32.