### PR TITLE
BUG: Fix QPC to Duration conversion loop

### DIFF
--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -863,12 +863,14 @@ impl ExportMachine {
         mut qpc: u64) -> u64 {
         let mut ns: u64 = 0;
 
-        while qpc >= freq {
-            ns += NANOS_IN_SEC;
-            qpc -= NANOS_IN_SEC;
-        }
+        if freq != 0 {
+            while qpc >= freq {
+                ns += NANOS_IN_SEC;
+                qpc -= freq;
+            }
 
-        ns += qpc * NANOS_IN_SEC / freq;
+            ns += qpc * NANOS_IN_SEC / freq;
+        }
 
         ns
     }


### PR DESCRIPTION
QPC seconds need to use QPC freq, and not the nanoseconds per-second constant. This is because the QPC freq is often not nanosecond resolution on Windows, while it is on Linux.