### PR TITLE
Fix one_collect Unit Tests

### DIFF
--- a/one_collect/src/helpers/exporting/symbols.rs
+++ b/one_collect/src/helpers/exporting/symbols.rs
@@ -757,6 +757,7 @@ impl ExportSymbolReader for R2RLoadedLayoutSymbolTransformer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn kernel_symbol_reader() {
@@ -903,10 +904,21 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn elf_symbol_reader() {
         #[cfg(target_arch = "x86_64")]
-        let path = "/usr/lib/x86_64-linux-gnu/libc.so.6";
+        let possible_paths = [
+            "/usr/lib/x86_64-linux-gnu/libc.so.6",
+            "/usr/lib/libc.so.6"
+        ];
 
         #[cfg(target_arch = "aarch64")]
-        let path = "/usr/lib/aarch64-linux-gnu/libc.so.6";
+        let possible_paths = [
+            "/usr/lib/aarch64-linux-gnu/libc.so.6",
+            "/usr/lib/libc.so.6"
+        ];
+
+        let path = possible_paths
+            .iter()
+            .find(|&p| Path::new(p).exists())
+            .expect("Could not find libc.so.6 in any expected location");
 
         if let Ok(file) = File::open(path) {
             let mut reader = ElfSymbolReader::new(file);

--- a/one_collect/src/helpers/uprobe.rs
+++ b/one_collect/src/helpers/uprobe.rs
@@ -83,14 +83,26 @@ pub fn enum_uprobe_modules(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn enum_uprobes_helper() {
         #[cfg(target_arch = "x86_64")]
-        let path = "/usr/lib/x86_64-linux-gnu/libc.so.6";
+        let possible_paths = [
+            "/usr/lib/x86_64-linux-gnu/libc.so.6",
+            "/usr/lib/libc.so.6"
+        ];
 
         #[cfg(target_arch = "aarch64")]
-        let path = "/usr/lib/aarch64-linux-gnu/libc.so.6";
+        let possible_paths = [
+            "/usr/lib/aarch64-linux-gnu/libc.so.6",
+            "/usr/lib/libc.so.6"
+        ];
+
+        let path = possible_paths
+            .iter()
+            .find(|&p| Path::new(p).exists())
+            .expect("Could not find libc.so.6 in any expected location");
 
         let mut found = false;
 

--- a/one_collect/src/tracefs.rs
+++ b/one_collect/src/tracefs.rs
@@ -429,6 +429,7 @@ impl TraceFS {
 mod tests {
     use super::*;
     use std::io::{Write, BufWriter};
+    use std::path::Path;
 
     #[test]
     fn it_works() {
@@ -523,10 +524,27 @@ mod tests {
             "malloc");
 
         #[cfg(all(target_arch = "x86_64"))]
+        let possible_paths = [
+            "/usr/lib/x86_64-linux-gnu/libc.so.6",
+            "/usr/lib/libc.so.6"
+        ];
+
+        #[cfg(all(target_arch = "aarch64"))]
+        let possible_paths = [
+            "/usr/lib/aarch64-linux-gnu/libc.so.6",
+            "/usr/lib/libc.so.6"
+        ];
+
+        let libc_path = possible_paths
+            .iter()
+            .find(|&p| Path::new(p).exists())
+            .expect("Could not find libc.so.6 in any expected location");
+
+        #[cfg(all(target_arch = "x86_64"))]
         let event = tracefs.register_uprobe(
             "unit_test",
             "malloc",
-            "/usr/lib/x86_64-linux-gnu/libc.so.6",
+            libc_path,
             0x0,
             "size=%di:u64").unwrap();
 
@@ -534,7 +552,7 @@ mod tests {
         let event = tracefs.register_uprobe(
             "unit_test",
             "malloc",
-            "/usr/lib/aarch64-linux-gnu/libc.so.6",
+            libc_path,
             0x0,
             "size=%x0:u64").unwrap();
 


### PR DESCRIPTION
Handle more cases where `libc.so.6` is in a different location.