### PR TITLE
DotNet: Update Linux IPC for user_events

### DIFF
--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -590,7 +590,7 @@ struct LinuxDotNetEvent {
     level: u8,
 }
 
-const DOTNET_HEADER_FIELDS: &str = "u8 version; u16 event_id; __rel_loc u8[] extension; __rel_loc u8[] payload; __rel_loc u8[] meta";
+const DOTNET_HEADER_FIELDS: &str = "u8 version; u16 event_id; __rel_loc u8[] extension; __rel_loc u8[] payload";
 
 struct DotNetEventDesc {
     name: String,


### PR DESCRIPTION
The DotNet Linux IPC updated the tracepoint format for user_event integration.

Remove meta field from format description, it is now part of the extension field.