### PR TITLE
Fix for Code Scanning Warnings: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/one-collect/security/code-scanning/7](https://github.com/microsoft/one-collect/security/code-scanning/7)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/ci.yml`. The best way to do this is to add the `permissions` key at the top level of the workflow, just below the `name` and before the `on` key. This will apply the permissions to all jobs in the workflow unless a job overrides them. Since the jobs only need to check out code and run builds/tests, the minimal required permission is `contents: read`. No additional permissions are needed for the current steps. You do not need to change any job definitions or steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
