### PR TITLE
record-trace: Add start/end to output types

### DIFF
--- a/record-trace/engine/src/lib.rs
+++ b/record-trace/engine/src/lib.rs
@@ -11,6 +11,8 @@ pub struct EngineOutput {
     on_live: Box<EngineOutputCallback>,
     on_normal: Box<EngineOutputCallback>,
     on_error: Box<EngineOutputCallback>,
+    on_start: Box<EngineOutputCallback>,
+    on_end: Box<EngineOutputCallback>,
     on_progress: Box<EngineOutputCallback>,
 }
 
@@ -20,6 +22,8 @@ impl Default for EngineOutput {
             on_live: Box::new(Self::default_normal),
             on_normal: Box::new(Self::default_normal),
             on_error: Box::new(Self::default_error),
+            on_start: Box::new(Self::default_normal),
+            on_end: Box::new(Self::default_normal),
             on_progress: Box::new(|_| { 0 }),
         }
     }
@@ -60,6 +64,18 @@ impl EngineOutput {
         self.on_progress = Box::new(callback);
     }
 
+    pub fn with_start(
+        &mut self,
+        callback: impl Fn(&str) -> i32 + 'static + Send + Sync) {
+        self.on_start = Box::new(callback);
+    }
+
+    pub fn with_end(
+        &mut self,
+        callback: impl Fn(&str) -> i32 + 'static + Send + Sync) {
+        self.on_end = Box::new(callback);
+    }
+
     fn live(&self, output: &str) -> i32 { (self.on_live)(output) }
 
     fn normal(&self, output: &str) -> i32 { (self.on_normal)(output) }
@@ -67,4 +83,8 @@ impl EngineOutput {
     fn error(&self, output: &str) -> i32 { (self.on_error)(output) }
 
     fn progress(&self, output: &str) -> i32 { (self.on_progress)(output) }
+
+    fn start(&self, output: &str) -> i32 { (self.on_start)(output) }
+
+    fn end(&self, output: &str) -> i32 { (self.on_end)(output) }
 }

--- a/record-trace/engine/src/recorder.rs
+++ b/record-trace/engine/src/recorder.rs
@@ -236,7 +236,7 @@ impl Recorder {
             // Print the banner telling the user that recording has started.
             if print_banner.load(Ordering::SeqCst) {
                 print_banner.store(false, Ordering::SeqCst);
-                parse_output.normal("Recording started.  Press CTRL+C to stop.");
+                parse_output.start("Recording started.");
             }
 
             // Give progress callback.
@@ -257,7 +257,7 @@ impl Recorder {
             }
         };
 
-        self.output.normal("\nRecording stopped.");
+        self.output.end("Recording stopped.");
         let mut exporter = exporter.borrow_mut();
 
         // Capture binary metdata and resolve symbols.

--- a/record-trace/ffi/src/lib.rs
+++ b/record-trace/ffi/src/lib.rs
@@ -9,6 +9,8 @@ const OUTPUT_NORMAL: i32 = 0;
 const OUTPUT_LIVE: i32 = 1;
 const OUTPUT_ERROR: i32 = 2;
 const OUTPUT_PROGRESS: i32 = 3;
+const OUTPUT_START: i32 = 4;
+const OUTPUT_END: i32 = 5;
 
 type COutputCallback = extern "C" fn(i32, *const u8, usize) -> i32;
 
@@ -46,6 +48,16 @@ extern "C" fn RecordTrace(
         output.with_progress(move |output| {
             let bytes = output.as_bytes();
             callback(OUTPUT_PROGRESS, bytes.as_ptr(), bytes.len())
+        });
+
+        output.with_start(move |output| {
+            let bytes = output.as_bytes();
+            callback(OUTPUT_START, bytes.as_ptr(), bytes.len())
+        });
+
+        output.with_end(move |output| {
+            let bytes = output.as_bytes();
+            callback(OUTPUT_END, bytes.as_ptr(), bytes.len())
         });
 
         let parser = RecordArgsParser::new(

--- a/record-trace/src/main.rs
+++ b/record-trace/src/main.rs
@@ -27,6 +27,19 @@ fn main() {
         }
     });
 
+    // Tell users to hit CTRL+C to stop.
+    output.with_start(|output| {
+        println!("{}  Press CTRL+C to stop.", output);
+        0
+    });
+
+    // Skip CTRL+C character before ending.
+    output.with_end(|output| {
+        println!("\n{}", output);
+        0
+    });
+
+    // Record.
     let mut recorder = Recorder::new(
         RecordArgs::parse(std::env::args_os()),
         output);


### PR DESCRIPTION
Previously record-trace would assume CTRL+C is the stopping mechanism. Now that we have an FFI, we cannot assume that detail. We need a way for solutions based on the FFI to communicate how to cancel (or any other details like distro information) when the recording starts.

Add with_start() and with_end() to EngineOutput to allow Rust tools to hook start/end.

Hook with_start() and with_end() to FFI using new values (OUTPUT_START/END) passed to the callback.

Remove CTRL+C from engine crate and move that banner printing to record-trace CLI to ensure we do not confuse folks. Each tool needs to communicate how to cancel the recording (if at all).