### PR TITLE
Fix ELF Symbol Resolution

### DIFF
--- a/one_collect/Cargo.lock
+++ b/one_collect/Cargo.lock
@@ -739,6 +739,7 @@ name = "ruwind"
 version = "0.0.0-dev"
 dependencies = [
  "cpp_demangle",
+ "libc",
  "rustc-demangle",
 ]
 

--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -1010,6 +1010,8 @@ pub trait ExportMachineOSHooks {
     fn os_qpc_freq() -> u64;
 
     fn os_cpu_count() -> u32;
+
+    fn os_system_page_size() -> u64;
 }
 
 pub type CommMap = HashMap<Option<usize>, Vec<u32>>;
@@ -1071,6 +1073,8 @@ impl ExportMachine {
     pub fn qpc_time() -> u64 { Self::os_qpc_time() }
 
     pub fn qpc_freq() -> u64 { Self::os_qpc_freq() }
+
+    pub fn system_page_size() -> u64 { Self::os_system_page_size() }
 
     pub fn qpc_to_ns(
         freq: u64,

--- a/one_collect/src/helpers/exporting/modulemetadata.rs
+++ b/one_collect/src/helpers/exporting/modulemetadata.rs
@@ -48,6 +48,8 @@ pub struct ElfModuleMetadata {
     build_id: Option<[u8; 20]>,
     debug_link_id: usize,
     version_metadata_id: usize,
+    p_vaddr: u64,
+    p_offset: u64,
 }
 
 impl ElfModuleMetadata {
@@ -56,6 +58,8 @@ impl ElfModuleMetadata {
             build_id: None,
             debug_link_id: 0,
             version_metadata_id: 0,
+            p_vaddr: 0,
+            p_offset: 0,
         }
     }
 
@@ -142,6 +146,22 @@ impl ElfModuleMetadata {
         metadata: &str,
         strings: &mut InternedStrings) {
         self.version_metadata_id = strings.to_id(metadata);
+    }
+
+    pub fn p_vaddr(&self) -> u64 {
+        self.p_vaddr
+    }
+
+    pub fn set_p_vaddr(&mut self, p_vaddr: u64) {
+        self.p_vaddr = p_vaddr;
+    }
+
+    pub fn p_offset(&self) -> u64 {
+        self.p_offset
+    }
+
+    pub fn set_p_offset(&mut self, p_offset: u64) {
+        self.p_offset = p_offset;
     }
 }
 

--- a/one_collect/src/helpers/exporting/modulemetadata.rs
+++ b/one_collect/src/helpers/exporting/modulemetadata.rs
@@ -254,7 +254,9 @@ mod tests {
         expected.push_str("{");
         expected.push_str("\"type\": \"ELF\",");
         expected.push_str("\"debug_link\": \"debug_link\",");
-        expected.push_str("\"build_id\": \"0101010101010101010101010101010101010101\"");
+        expected.push_str("\"build_id\": \"0101010101010101010101010101010101010101\",");
+        expected.push_str("\"p_vaddr\": \"0x0\",");
+        expected.push_str("\"p_offset\": \"0x0\"");
         expected.push_str("}");
 
         assert_eq!(expected, out);

--- a/one_collect/src/helpers/exporting/modulemetadata.rs
+++ b/one_collect/src/helpers/exporting/modulemetadata.rs
@@ -85,6 +85,9 @@ impl ElfModuleMetadata {
             out.push_str("\",");
         }
 
+        out.push_str(&format!("\"p_vaddr\": \"0x{:x}\",", self.p_vaddr));
+        out.push_str(&format!("\"p_offset\": \"0x{:x}\",", self.p_offset));
+
         /* Remove trailing comma if it exists */
         if out.ends_with(',') {
             out.pop();

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -561,6 +561,14 @@ impl ExportProcessOSHooks for ExportProcess {
             }
         }
     }
+
+    fn system_page_mask(&self) -> u64 {
+        system_page_mask()
+    }
+
+    fn system_page_size(&self) -> u64 {
+        system_page_size()
+    }
 }
 
 pub(crate) fn default_export_settings() -> ExportSettings {

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -34,8 +34,6 @@ pub type Session = PerfSession;
 /* OS Specific Session Builder Type */
 pub type SessionBuilder = RingBufSessionBuilder;
 
-const PAGE_MASK: u64 = 0xFFFFFFFFFFFFF000;
-
 #[derive(Clone)]
 pub(crate) struct OSExportProcess {
     root_fs: Option<OpenAt>,
@@ -120,6 +118,8 @@ impl ExportProcessLinuxExt for ExportProcess {
             return;
         }
 
+        let page_mask = system_page_mask();
+
         for map_index in 0..self.mappings().len() {
             let map = self.mappings().get(map_index).unwrap();
             if map.anon() {
@@ -169,8 +169,8 @@ impl ExportProcessLinuxExt for ExportProcess {
                 for sym_file in sym_files {
 
                     // Page align the values from the load header.
-                    let p_offset = metadata.p_offset() & PAGE_MASK;
-                    let p_vaddr = metadata.p_vaddr() & PAGE_MASK;
+                    let p_offset = metadata.p_offset() & page_mask;
+                    let p_vaddr = metadata.p_vaddr() & page_mask;
 
                     let load_header = ElfLoadHeader::new(p_offset, p_vaddr);
                     let mut sym_reader = ElfSymbolReader::new(sym_file, load_header);

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -34,6 +34,8 @@ pub type Session = PerfSession;
 /* OS Specific Session Builder Type */
 pub type SessionBuilder = RingBufSessionBuilder;
 
+const PAGE_MASK: u64 = 0xFFFFFFFFFFFFF000;
+
 #[derive(Clone)]
 pub(crate) struct OSExportProcess {
     root_fs: Option<OpenAt>,
@@ -165,7 +167,13 @@ impl ExportProcessLinuxExt for ExportProcess {
                     strings);
 
                 for sym_file in sym_files {
-                    let mut sym_reader = ElfSymbolReader::new(sym_file);
+
+                    // Page align the values from the load header.
+                    let p_offset = metadata.p_offset() & PAGE_MASK;
+                    let p_vaddr = metadata.p_vaddr() & PAGE_MASK;
+
+                    let load_header = ElfLoadHeader::new(p_offset, p_vaddr);
+                    let mut sym_reader = ElfSymbolReader::new(sym_file, load_header);
                     let map_mut = self.mappings_mut().get_mut(map_index).unwrap();
 
                     map_mut.add_matching_symbols(
@@ -1177,6 +1185,12 @@ impl OSExportMachine {
                                     let mut build_id: [u8; 20] = [0; 20];
                                     if let Ok(id) = read_build_id(&mut reader, &sections, &section_offsets, &mut build_id) {
                                         elf_metadata.set_build_id(id);
+                                    }
+
+                                    // Read the load header from the binary to get p_vaddr and p_offset
+                                    if let Ok(load_header) = get_load_header(&mut reader) {
+                                        elf_metadata.set_p_offset(load_header.p_offset());
+                                        elf_metadata.set_p_vaddr(load_header.p_vaddr());
                                     }
 
                                     if read_package_metadata(&mut reader, &sections, &section_offsets, &mut package_buf).is_ok() {

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -1420,6 +1420,11 @@ impl ExportMachineOSHooks for ExportMachine {
             libc::sysconf(libc::_SC_NPROCESSORS_ONLN) as u32
         }
     }
+
+    fn os_system_page_size() -> u64 {
+        system_page_size()
+    }
+
 }
 
 impl ExportBuilderHelp for RingBufSessionBuilder {

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -22,6 +22,8 @@ use crate::helpers::exporting::*;
 use crate::helpers::exporting::process::{ExportProcessOSHooks, MetricValue};
 use crate::helpers::exporting::universal::*;
 use crate::helpers::exporting::modulemetadata::{ModuleMetadata, ElfModuleMetadata};
+use crate::page_size_to_mask;
+use crate::os::system_page_size;
 
 use ruwind::elf::*;
 use ruwind::{ModuleAccessor, UnwindType};
@@ -118,7 +120,8 @@ impl ExportProcessLinuxExt for ExportProcess {
             return;
         }
 
-        let page_mask = system_page_mask();
+        let page_size = self.system_page_size();
+        let page_mask = self.system_page_mask();
 
         for map_index in 0..self.mappings().len() {
             let map = self.mappings().get(map_index).unwrap();
@@ -173,7 +176,7 @@ impl ExportProcessLinuxExt for ExportProcess {
                     let p_vaddr = metadata.p_vaddr() & page_mask;
 
                     let load_header = ElfLoadHeader::new(p_offset, p_vaddr);
-                    let mut sym_reader = ElfSymbolReader::new(sym_file, load_header);
+                    let mut sym_reader = ElfSymbolReader::new(sym_file, load_header, page_size);
                     let map_mut = self.mappings_mut().get_mut(map_index).unwrap();
 
                     map_mut.add_matching_symbols(
@@ -563,7 +566,8 @@ impl ExportProcessOSHooks for ExportProcess {
     }
 
     fn system_page_mask(&self) -> u64 {
-        system_page_mask()
+        let page_size = self.system_page_size();
+        page_size_to_mask(page_size)
     }
 
     fn system_page_size(&self) -> u64 {

--- a/one_collect/src/helpers/exporting/os/windows.rs
+++ b/one_collect/src/helpers/exporting/os/windows.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 use std::collections::hash_map::Entry::Occupied;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use std::fs::File;
 
@@ -64,6 +64,44 @@ impl OSExportProcess {
     }
 }
 
+static PAGE_MASK_CACHE: OnceLock<u64> = OnceLock::new();
+
+/// Gets the system page size in bytes on Windows
+fn system_page_size() -> u64 {
+    extern "system" {
+        fn GetSystemInfo(lpSystemInfo: *mut SystemInfo);
+    }
+
+    #[repr(C)]
+    struct SystemInfo {
+        processor_architecture: u16,
+        reserved: u16,
+        page_size: u32,
+        minimum_application_address: *mut std::ffi::c_void,
+        maximum_application_address: *mut std::ffi::c_void,
+        active_processor_mask: *mut std::ffi::c_void,
+        number_of_processors: u32,
+        processor_type: u32,
+        allocation_granularity: u32,
+        processor_level: u16,
+        processor_revision: u16,
+    }
+
+    unsafe {
+        let mut system_info: SystemInfo = std::mem::zeroed();
+        GetSystemInfo(&mut system_info);
+        system_info.page_size as u64
+    }
+}
+
+/// Gets the system page mask, caching the result for the life of the process
+fn system_page_mask() -> u64 {
+    *PAGE_MASK_CACHE.get_or_init(|| {
+        let page_size = system_page_size();
+        !((page_size - 1) as u64)
+    })
+}
+
 #[cfg(target_os = "windows")]
 impl ExportProcessOSHooks for ExportProcess {
     fn os_open_file(
@@ -71,6 +109,14 @@ impl ExportProcessOSHooks for ExportProcess {
         path: &Path) -> anyhow::Result<File> {
         let file = File::open(path)?;
         Ok(file)
+    }
+
+    fn system_page_mask(&self) -> u64 {
+        system_page_mask()
+    }
+
+    fn system_page_size(&self) -> u64 {
+        system_page_size()
     }
 }
 

--- a/one_collect/src/helpers/exporting/os/windows.rs
+++ b/one_collect/src/helpers/exporting/os/windows.rs
@@ -925,6 +925,10 @@ impl ExportMachineOSHooks for ExportMachine {
             GetActiveProcessorCount(0xFFFF)
         }
     }
+
+    fn os_system_page_size() -> u64 {
+        system_page_size()
+    }
 }
 
 impl ExportSessionHelp for EtwSession {

--- a/one_collect/src/helpers/exporting/os/windows.rs
+++ b/one_collect/src/helpers/exporting/os/windows.rs
@@ -11,6 +11,8 @@ use crate::etw::*;
 use crate::helpers::exporting::*;
 use crate::helpers::exporting::process::ExportProcessOSHooks;
 use crate::helpers::exporting::universal::*;
+use crate::os::system_page_size;
+use crate::page_size_to_mask;
 
 /* OS Specific Session Type */
 pub type Session = EtwSession;
@@ -64,44 +66,6 @@ impl OSExportProcess {
     }
 }
 
-static PAGE_MASK_CACHE: OnceLock<u64> = OnceLock::new();
-
-/// Gets the system page size in bytes on Windows
-fn system_page_size() -> u64 {
-    extern "system" {
-        fn GetSystemInfo(lpSystemInfo: *mut SystemInfo);
-    }
-
-    #[repr(C)]
-    struct SystemInfo {
-        processor_architecture: u16,
-        reserved: u16,
-        page_size: u32,
-        minimum_application_address: *mut std::ffi::c_void,
-        maximum_application_address: *mut std::ffi::c_void,
-        active_processor_mask: *mut std::ffi::c_void,
-        number_of_processors: u32,
-        processor_type: u32,
-        allocation_granularity: u32,
-        processor_level: u16,
-        processor_revision: u16,
-    }
-
-    unsafe {
-        let mut system_info: SystemInfo = std::mem::zeroed();
-        GetSystemInfo(&mut system_info);
-        system_info.page_size as u64
-    }
-}
-
-/// Gets the system page mask, caching the result for the life of the process
-fn system_page_mask() -> u64 {
-    *PAGE_MASK_CACHE.get_or_init(|| {
-        let page_size = system_page_size();
-        !((page_size - 1) as u64)
-    })
-}
-
 #[cfg(target_os = "windows")]
 impl ExportProcessOSHooks for ExportProcess {
     fn os_open_file(
@@ -112,7 +76,8 @@ impl ExportProcessOSHooks for ExportProcess {
     }
 
     fn system_page_mask(&self) -> u64 {
-        system_page_mask()
+        let page_size = self.system_page_size();
+        page_size_to_mask(page_size)
     }
 
     fn system_page_size(&self) -> u64 {

--- a/one_collect/src/helpers/exporting/process.rs
+++ b/one_collect/src/helpers/exporting/process.rs
@@ -555,6 +555,10 @@ pub trait ExportProcessOSHooks {
     fn os_open_file(
         &self,
         path: &Path) -> anyhow::Result<File>;
+
+    fn system_page_mask(&self) -> u64;
+
+    fn system_page_size(&self) -> u64;
 }
 
 impl Unwindable for ExportProcess {
@@ -674,10 +678,10 @@ impl ExportProcess {
             b.symbol().start().cmp(&a.symbol().start())
         });
 
-        /* We will add dynamic mappings at a page boundary of 4KB */
+        /* We will add dynamic mappings at a page boundary */
         let mut dyn_mappings: Vec<ExportMapping> = Vec::new();
-        let page_mask: u64 = 0xFFFFFFFFFFFFF000;
-        let page_size: u64 = 4096;
+        let page_mask = self.system_page_mask();
+        let page_size = self.system_page_size();
 
         /* Mutably drain without references */
         while !self.dyn_symbols.is_empty() {

--- a/one_collect/src/helpers/exporting/symbols.rs
+++ b/one_collect/src/helpers/exporting/symbols.rs
@@ -344,9 +344,9 @@ pub struct ElfSymbolReader<'a> {
 }
 
 impl<'a> ElfSymbolReader<'a> {
-    pub fn new(file: File, load_header: ElfLoadHeader) -> Self {
+    pub fn new(file: File, load_header: ElfLoadHeader, system_page_size: u64) -> Self {
         Self {
-            iterator: ElfSymbolIterator::new(file, load_header),
+            iterator: ElfSymbolIterator::new(file, load_header, system_page_size),
             current_sym: ElfSymbol::new(),
             current_sym_valid: false,
         }
@@ -757,6 +757,7 @@ impl ExportSymbolReader for R2RLoadedLayoutSymbolTransformer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::os::system_page_size;
     use std::path::Path;
 
     #[test]
@@ -922,7 +923,8 @@ mod tests {
 
         if let Ok(file) = File::open(path) {
             let load_header = ElfLoadHeader::new(0, 0);
-            let mut reader = ElfSymbolReader::new(file, load_header);
+            let system_page_size = system_page_size();
+            let mut reader = ElfSymbolReader::new(file, load_header, system_page_size);
             reader.reset();
 
             let mut actual_count = 0;

--- a/one_collect/src/helpers/exporting/symbols.rs
+++ b/one_collect/src/helpers/exporting/symbols.rs
@@ -3,7 +3,7 @@
 
 use std::{fs::File, io::{BufRead, BufReader, Seek, SeekFrom}};
 use std::collections::HashSet;
-use ruwind::elf::{ElfSymbol, ElfSymbolIterator};
+use ruwind::elf::{ElfLoadHeader, ElfSymbol, ElfSymbolIterator};
 
 use crate::helpers::exporting::ExportMachine;
 
@@ -344,9 +344,9 @@ pub struct ElfSymbolReader<'a> {
 }
 
 impl<'a> ElfSymbolReader<'a> {
-    pub fn new(file: File) -> Self {
+    pub fn new(file: File, load_header: ElfLoadHeader) -> Self {
         Self {
-            iterator: ElfSymbolIterator::new(file),
+            iterator: ElfSymbolIterator::new(file, load_header),
             current_sym: ElfSymbol::new(),
             current_sym_valid: false,
         }
@@ -921,7 +921,8 @@ mod tests {
             .expect("Could not find libc.so.6 in any expected location");
 
         if let Ok(file) = File::open(path) {
-            let mut reader = ElfSymbolReader::new(file);
+            let load_header = ElfLoadHeader::new(0, 0);
+            let mut reader = ElfSymbolReader::new(file, load_header);
             reader.reset();
 
             let mut actual_count = 0;

--- a/one_collect/src/helpers/uprobe.rs
+++ b/one_collect/src/helpers/uprobe.rs
@@ -42,8 +42,11 @@ pub fn enum_uprobes(
     elf::get_section_metadata(&mut file, None, SHT_SYMTAB, &mut sections)?;
     elf::get_section_metadata(&mut file, None, SHT_DYNSYM, &mut sections)?;
 
+    /* Get the load header */
+    let load_header = elf::get_load_header(&mut file)?;
+
     /* Get symbols from those sections and pass to caller */
-    elf::get_symbols(&mut file, &sections, move |symbol| {
+    elf::get_symbols(&mut file, &load_header, &sections, move |symbol| {
         let probe = UProbe::new(
             "Func",
             symbol.name(),

--- a/one_collect/src/helpers/uprobe.rs
+++ b/one_collect/src/helpers/uprobe.rs
@@ -6,6 +6,8 @@ use std::fs::File;
 use anyhow::Result;
 
 use crate::procfs::*;
+use super::super::page_size_to_mask;
+use super::super::os::linux::system_page_size;
 
 pub struct UProbe<'a> {
     probe_type: &'a str,
@@ -45,8 +47,12 @@ pub fn enum_uprobes(
     /* Get the load header */
     let load_header = elf::get_load_header(&mut file)?;
 
+    /* Get the system page mask */
+    let system_page_size = system_page_size();
+    let system_page_mask = page_size_to_mask(system_page_size);
+
     /* Get symbols from those sections and pass to caller */
-    elf::get_symbols(&mut file, &load_header, &sections, move |symbol| {
+    elf::get_symbols(&mut file, &load_header, system_page_mask, &sections, move |symbol| {
         let probe = UProbe::new(
             "Func",
             symbol.name(),

--- a/one_collect/src/lib.rs
+++ b/one_collect/src/lib.rs
@@ -36,6 +36,7 @@ pub mod event;
 pub mod sharing;
 pub mod helpers;
 pub mod intern;
+pub mod os;
 
 #[cfg(any(doc, target_os = "linux"))]
 pub mod tracefs;
@@ -61,6 +62,10 @@ pub use pathbuf_ext::{PathBufInteger};
 
 pub type IOResult<T> = std::io::Result<T>;
 pub type IOError = std::io::Error;
+
+fn page_size_to_mask(page_size: u64) -> u64 {
+    !((page_size - 1) as u64)
+}
 
 pub fn io_error(message: &str) -> IOError {
     IOError::new(

--- a/one_collect/src/os/linux.rs
+++ b/one_collect/src/os/linux.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+pub fn system_page_size() -> u64 {
+    unsafe {
+        let page_size = libc::sysconf(libc::_SC_PAGESIZE);
+        if page_size > 0 {
+            page_size as u64
+        } else {
+            panic!("Failed to get system page size via sysconf(_SC_PAGESIZE)");
+        }
+    }
+}

--- a/one_collect/src/os/mod.rs
+++ b/one_collect/src/os/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/* Windows */
+#[cfg(any(doc, target_os = "windows"))]
+pub mod windows;
+
+#[cfg(target_os = "windows")]
+pub use windows::*;
+
+/* Linux */
+#[cfg(any(doc, target_os = "linux"))]
+pub mod linux;
+
+#[cfg(target_os = "linux")]
+pub use linux::*;

--- a/one_collect/src/os/windows.rs
+++ b/one_collect/src/os/windows.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+pub fn system_page_size() -> u64 {
+    extern "system" {
+        fn GetSystemInfo(lpSystemInfo: *mut SystemInfo);
+    }
+
+    #[repr(C)]
+    struct SystemInfo {
+        processor_architecture: u16,
+        reserved: u16,
+        page_size: u32,
+        minimum_application_address: *mut std::ffi::c_void,
+        maximum_application_address: *mut std::ffi::c_void,
+        active_processor_mask: *mut std::ffi::c_void,
+        number_of_processors: u32,
+        processor_type: u32,
+        allocation_granularity: u32,
+        processor_level: u16,
+        processor_revision: u16,
+    }
+
+    unsafe {
+        let mut system_info: SystemInfo = std::mem::zeroed();
+        GetSystemInfo(&mut system_info);
+        system_info.page_size as u64
+    }
+}

--- a/record-trace/Cargo.lock
+++ b/record-trace/Cargo.lock
@@ -634,6 +634,7 @@ name = "ruwind"
 version = "0.0.0-dev"
 dependencies = [
  "cpp_demangle",
+ "libc",
  "rustc-demangle",
 ]
 

--- a/ruwind/Cargo.lock
+++ b/ruwind/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,5 +34,6 @@ name = "ruwind"
 version = "0.0.0-dev"
 dependencies = [
  "cpp_demangle",
+ "libc",
  "rustc-demangle",
 ]

--- a/ruwind/Cargo.toml
+++ b/ruwind/Cargo.toml
@@ -9,3 +9,4 @@ repository = "https://github.com/microsoft/one-collect"
 [dependencies]
 cpp_demangle = "0.4.3"
 rustc-demangle = "0.1"
+libc = "0.2"

--- a/ruwind/src/elf.rs
+++ b/ruwind/src/elf.rs
@@ -26,7 +26,7 @@ pub const SYMBOL_TYPE_ELF_DYNSYM: u32 = 2;
 static PAGE_MASK_CACHE: OnceLock<u64> = OnceLock::new();
 
 /// Gets the system page size in bytes
-fn system_page_size() -> u64 {
+pub fn system_page_size() -> u64 {
     unsafe {
         let page_size = libc::sysconf(libc::_SC_PAGESIZE);
         if page_size > 0 {

--- a/ruwind/src/elf.rs
+++ b/ruwind/src/elf.rs
@@ -27,13 +27,20 @@ static PAGE_MASK_CACHE: OnceLock<u64> = OnceLock::new();
 
 /// Gets the system page size in bytes
 pub fn system_page_size() -> u64 {
-    unsafe {
-        let page_size = libc::sysconf(libc::_SC_PAGESIZE);
-        if page_size > 0 {
-            page_size as u64
-        } else {
-            panic!("Failed to get system page size via sysconf(_SC_PAGESIZE)");
+    #[cfg(target_os = "linux")]
+    {
+        unsafe {
+            let page_size = libc::sysconf(libc::_SC_PAGESIZE);
+            if page_size > 0 {
+                page_size as u64
+            } else {
+                panic!("Failed to get system page size via sysconf(_SC_PAGESIZE)");
+            }
         }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        panic!("system_page_size() is not supported on this platform.");
     }
 }
 

--- a/ruwind/src/elf.rs
+++ b/ruwind/src/elf.rs
@@ -22,6 +22,8 @@ pub const SHT_DYNSYM: ElfWord = 11;
 pub const SYMBOL_TYPE_ELF_SYMTAB: u32 = 1;
 pub const SYMBOL_TYPE_ELF_DYNSYM: u32 = 2;
 
+const PAGE_MASK: u64 = 0xFFFFFFFFFFFFF000;
+
 pub struct ElfSymbol {
     start: u64,
     end: u64,
@@ -89,30 +91,30 @@ impl SectionMetadata {
 }
 
 pub struct ElfLoadHeader {
-    file_offset: u64,
-    align: u64
+    p_offset: u64,
+    p_vaddr: u64,
 }
 
 impl ElfLoadHeader {
     pub fn new (
-        file_offset: u64,
-        align: u64) -> Self {
+        p_offset: u64,
+        p_vaddr: u64) -> Self {
         Self {
-            file_offset,
-            align
+            p_offset,
+            p_vaddr,
         }
     }
 
     pub fn default() -> Self {
-        Self::new(0,0)
+        Self::new(0, 0)
     }
 
-    pub fn file_offset(&self) -> u64 {
-        self.file_offset
+    pub fn p_offset(&self) -> u64 {
+        self.p_offset
     }
 
-    pub fn align(&self) -> u64 {
-        self.align
+    pub fn p_vaddr(&self) -> u64 {
+        self.p_vaddr
     }
 
 }
@@ -121,7 +123,6 @@ pub struct ElfSymbolIterator<'a> {
     phantom: PhantomData<&'a ()>,
     reader: BufReader<File>,
     
-    all_sections: Vec<SectionMetadata>,
     sections: Vec<SectionMetadata>,
     section_index: usize,
     section_offsets: Vec<u64>,
@@ -136,16 +137,16 @@ pub struct ElfSymbolIterator<'a> {
 }
 
 impl<'a> ElfSymbolIterator<'a> {
-    pub fn new(file: File) -> Self {
+    pub fn new(file: File, load_header: ElfLoadHeader) -> Self {
+
         Self {
             phantom: std::marker::PhantomData,
             reader: BufReader::new(file),
-            all_sections: Vec::new(),
             sections: Vec::new(),
             section_index: 0,
             section_offsets: Vec::new(),
             section_str_offset: 0,
-            load_header: ElfLoadHeader::default(),
+            load_header: load_header,
             entry_count: 0,
             entry_index: 0,
             reset: true,
@@ -176,11 +177,7 @@ impl<'a> ElfSymbolIterator<'a> {
         // Seek to the beginning of the file in-case this is not the first call to initialize.
         self.reader.seek(SeekFrom::Start(0))?;
 
-        // Get the load offset.
-        self.load_header = get_load_header(&mut self.reader)?;
-
         // Read the section metadata and store it.
-        enum_section_metadata(&mut self.reader, None, None, &mut self.all_sections)?;
         get_section_metadata(&mut self.reader, None, SHT_SYMTAB, &mut self.sections)?;
         get_section_metadata(&mut self.reader, None, SHT_DYNSYM, &mut self.sections)?;
         get_section_offsets(&mut self.reader, None, &mut self.section_offsets)?;
@@ -234,7 +231,6 @@ impl<'a> ElfSymbolIterator<'a> {
             let result = get_symbol(
                 &mut self.reader,
                 section,
-                &self.all_sections,
                 self.entry_index,
                 self.section_str_offset,
                 &self.load_header,
@@ -277,23 +273,20 @@ pub fn get_str(
 
 fn get_symbols32(
     reader: &mut (impl Read + Seek),
+    load_header: &ElfLoadHeader,
     metadata: &SectionMetadata,
-    sections: &Vec<SectionMetadata>,
     count: u64,
     str_offset: u64,
     mut callback: impl FnMut(&ElfSymbol)) -> Result<(), Error> {
     let mut symbol = ElfSymbol::new();
-    
-    let load_header = get_load_header(reader)?;
 
     for i in 0..count {
         if get_symbol32(
             reader,
             metadata,
-            sections,
             i,
             str_offset,
-            &load_header,
+            load_header,
             &mut symbol).is_err() {
                 continue;
         }
@@ -306,40 +299,17 @@ fn get_symbols32(
 
 fn symbol_rva(
     value: u64,
-    sec_index: usize,
-    sections: &Vec<SectionMetadata>,
     load_header: &ElfLoadHeader) -> u64 {
-    if sec_index >= sections.len() {
-        return value;
-    }
 
-    let section = &sections[sec_index];
-
-    if section.sec_type == SHT_NOBITS {
-        if load_header.file_offset() % load_header.align() != 0 {
-            // Work around invalid file_offset due to a bug in LLVM.
-            // https://reviews.llvm.org/D60131
-            let offset = align_up(load_header.file_offset, load_header.align);
-            return value - offset;
-        }
-        else {
-            return value;   
-        }
-    }
-
-    (value - section.address) + section.offset
-}
-
-fn align_up(
-    value: u64,
-    align: u64) -> u64 {
-    (value + align - 1) & !(align - 1)
+    // The load header values must be page aligned.
+    assert!(load_header.p_vaddr() & PAGE_MASK == load_header.p_vaddr());
+    assert!(load_header.p_offset() & PAGE_MASK == load_header.p_offset());
+    (value - load_header.p_vaddr()) + load_header.p_offset()
 }
 
 fn get_symbol32(
     reader: &mut (impl Read + Seek),
     metadata: &SectionMetadata,
-    sections: &Vec<SectionMetadata>,
     sym_index: u64,
     str_offset: u64,
     load_header: &ElfLoadHeader,
@@ -353,7 +323,7 @@ fn get_symbol32(
         return Err(Error::new(std::io::ErrorKind::InvalidData, "Invalid symbol"));
     }
 
-    symbol.start = symbol_rva(sym.st_value as u64, sym.st_shndx as usize, sections, load_header);
+    symbol.start = symbol_rva(sym.st_value as u64, load_header);
     symbol.end = symbol.start + (sym.st_size as u64 - 1);
     let str_pos = sym.st_name as u64 + str_offset;
 
@@ -365,23 +335,20 @@ fn get_symbol32(
 
 fn get_symbols64(
     reader: &mut (impl Read + Seek),
+    load_header: &ElfLoadHeader,
     metadata: &SectionMetadata,
-    sections: &Vec<SectionMetadata>,
     count: u64,
     str_offset: u64,
     mut callback: impl FnMut(&ElfSymbol)) -> Result<(), Error> {
     let mut symbol = ElfSymbol::new();
 
-    let load_header = get_load_header(reader)?;
-
     for i in 0..count {
         if get_symbol64(
             reader,
             metadata,
-            sections,
             i,
             str_offset,
-            &load_header,
+            load_header,
             &mut symbol).is_err() {
                 continue;
         }
@@ -395,7 +362,6 @@ fn get_symbols64(
 fn get_symbol64(
     reader: &mut (impl Read + Seek),
     metadata: &SectionMetadata,
-    sections: &Vec<SectionMetadata>,
     sym_index: u64,
     str_offset: u64,
     load_header: &ElfLoadHeader,
@@ -409,7 +375,7 @@ fn get_symbol64(
         return Err(Error::new(std::io::ErrorKind::InvalidData, "Invalid symbol"));
     }
 
-    symbol.start = symbol_rva(sym.st_value as u64, sym.st_shndx as usize, sections, load_header);
+    symbol.start = symbol_rva(sym.st_value as u64, load_header);
     symbol.end = symbol.start + (sym.st_size - 1);
     let str_pos = sym.st_name as u64 + str_offset;
 
@@ -451,6 +417,7 @@ fn demangle_symbol(
 
 pub fn get_symbols(
     reader: &mut (impl Read + Seek),
+    load_header: &ElfLoadHeader,
     metadata: &Vec<SectionMetadata>,
     mut callback: impl FnMut(&ElfSymbol)) -> Result<(), Error> {
     let mut offsets: Vec<u64> = Vec::new();
@@ -471,10 +438,10 @@ pub fn get_symbols(
 
         match m.class {
             ELFCLASS32 => {
-                get_symbols32(reader, m, &sections, count, str_offset, &mut callback)?;
+                get_symbols32(reader, load_header, m, count, str_offset, &mut callback)?;
             },
             ELFCLASS64 => {
-                get_symbols64(reader, m, &sections, count, str_offset, &mut callback)?;
+                get_symbols64(reader, load_header, m, count, str_offset, &mut callback)?;
             },
             _ => {
                 /* Unknown, no symbols */
@@ -488,17 +455,16 @@ pub fn get_symbols(
 pub fn get_symbol(
     reader: &mut (impl Read + Seek),
     metadata: &SectionMetadata,
-    sections: &Vec<SectionMetadata>,
     sym_index: u64,
     str_offset: u64,
     load_header: &ElfLoadHeader,
     symbol: &mut ElfSymbol) -> Result<(), Error> {
     match metadata.class {
         ELFCLASS32 => {
-            return get_symbol32(reader, metadata, sections, sym_index, str_offset, load_header, symbol);
+            return get_symbol32(reader, metadata, sym_index, str_offset, load_header, symbol);
         },
         ELFCLASS64 => {
-            return get_symbol64(reader, metadata, sections, sym_index, str_offset, load_header, symbol);
+            return get_symbol64(reader, metadata, sym_index, str_offset, load_header, symbol);
         }
         _ => {
             /* Unknown, no symbols */
@@ -1214,7 +1180,7 @@ fn get_load_header32(
             (pheader.p_flags & PF_X) == PF_X {
             return Ok(ElfLoadHeader::new(
                 pheader.p_offset as u64,
-                pheader.p_align as u64));
+                pheader.p_vaddr as u64));
         }
         sec_offset += header.e_phentsize as u64;
     }
@@ -1241,7 +1207,7 @@ fn get_load_header64(
             (pheader.p_flags & PF_X) == PF_X {
                 return Ok(ElfLoadHeader::new(
                     pheader.p_offset,
-                    pheader.p_align));
+                    pheader.p_vaddr));
         }
         sec_offset += header.e_phentsize as u64;
     }
@@ -1283,13 +1249,16 @@ mod tests {
         let mut file = File::open(path).unwrap();
         let mut sections = Vec::new();
 
+        /* Get load header */
+        let load_header = elf::get_load_header(&mut file).unwrap();
+
         /* Get Dyn and Function Symbols */
         get_section_metadata(&mut file, None, SHT_SYMTAB, &mut sections).unwrap();
         get_section_metadata(&mut file, None, SHT_DYNSYM, &mut sections).unwrap();
 
         let mut found = false;
 
-        get_symbols(&mut file, &sections, |symbol| {
+        get_symbols(&mut file, &load_header, &sections, |symbol| {
             if symbol.name() == "malloc" {
                 println!("{} - {}: {}", symbol.start, symbol.end, symbol.name());
                 found = true;

--- a/ruwind/src/elf.rs
+++ b/ruwind/src/elf.rs
@@ -6,6 +6,7 @@ use std::io::{BufReader, Error, Read, Seek, SeekFrom};
 use std::marker::PhantomData;
 use std::mem::{zeroed, size_of};
 use std::slice;
+use std::sync::OnceLock;
 use cpp_demangle::{DemangleOptions, Symbol};
 use rustc_demangle::try_demangle;
 
@@ -22,7 +23,27 @@ pub const SHT_DYNSYM: ElfWord = 11;
 pub const SYMBOL_TYPE_ELF_SYMTAB: u32 = 1;
 pub const SYMBOL_TYPE_ELF_DYNSYM: u32 = 2;
 
-const PAGE_MASK: u64 = 0xFFFFFFFFFFFFF000;
+static PAGE_MASK_CACHE: OnceLock<u64> = OnceLock::new();
+
+/// Gets the system page size in bytes
+fn system_page_size() -> u64 {
+    unsafe {
+        let page_size = libc::sysconf(libc::_SC_PAGESIZE);
+        if page_size > 0 {
+            page_size as u64
+        } else {
+            panic!("Failed to get system page size via sysconf(_SC_PAGESIZE)");
+        }
+    }
+}
+
+/// Gets the system page mask, caching the result for the life of the process
+pub fn system_page_mask() -> u64 {
+    *PAGE_MASK_CACHE.get_or_init(|| {
+        let page_size = system_page_size();
+        !((page_size - 1) as u64)
+    })
+}
 
 pub struct ElfSymbol {
     start: u64,
@@ -302,8 +323,8 @@ fn symbol_rva(
     load_header: &ElfLoadHeader) -> u64 {
 
     // The load header values must be page aligned.
-    assert!(load_header.p_vaddr() & PAGE_MASK == load_header.p_vaddr());
-    assert!(load_header.p_offset() & PAGE_MASK == load_header.p_offset());
+    assert!(load_header.p_vaddr() & system_page_mask() == load_header.p_vaddr());
+    assert!(load_header.p_offset() & system_page_mask() == load_header.p_offset());
     (value - load_header.p_vaddr()) + load_header.p_offset()
 }
 
@@ -1335,5 +1356,21 @@ mod tests {
 
         assert!(elf::build_id_equals(&build_id_1, &build_id_2));
         assert!(!elf::build_id_equals(&build_id_1, &build_id_3));
+    }
+
+    #[test]
+    fn page_size_functions() {
+        // Test that system_page_size returns a reasonable value
+        let page_size = system_page_size();
+        assert!(page_size > 0);
+        assert!(page_size <= 65536); // Common range: 4KB to 64KB
+
+        // Test that system_page_mask is consistent with page_size
+        let page_mask = system_page_mask();
+        let expected_mask = !((page_size - 1) as u64);
+        assert_eq!(page_mask, expected_mask);
+
+        // Test that page size is a power of 2
+        assert_eq!(page_size & (page_size - 1), 0);
     }
 }

--- a/ruwind/src/elf.rs
+++ b/ruwind/src/elf.rs
@@ -6,7 +6,6 @@ use std::io::{BufReader, Error, Read, Seek, SeekFrom};
 use std::marker::PhantomData;
 use std::mem::{zeroed, size_of};
 use std::slice;
-use std::sync::OnceLock;
 use cpp_demangle::{DemangleOptions, Symbol};
 use rustc_demangle::try_demangle;
 
@@ -22,35 +21,6 @@ pub const SHT_DYNSYM: ElfWord = 11;
 // which types of symbols are present in a binary.
 pub const SYMBOL_TYPE_ELF_SYMTAB: u32 = 1;
 pub const SYMBOL_TYPE_ELF_DYNSYM: u32 = 2;
-
-static PAGE_MASK_CACHE: OnceLock<u64> = OnceLock::new();
-
-/// Gets the system page size in bytes
-pub fn system_page_size() -> u64 {
-    #[cfg(target_os = "linux")]
-    {
-        unsafe {
-            let page_size = libc::sysconf(libc::_SC_PAGESIZE);
-            if page_size > 0 {
-                page_size as u64
-            } else {
-                panic!("Failed to get system page size via sysconf(_SC_PAGESIZE)");
-            }
-        }
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        panic!("system_page_size() is not supported on this platform.");
-    }
-}
-
-/// Gets the system page mask, caching the result for the life of the process
-pub fn system_page_mask() -> u64 {
-    *PAGE_MASK_CACHE.get_or_init(|| {
-        let page_size = system_page_size();
-        !((page_size - 1) as u64)
-    })
-}
 
 pub struct ElfSymbol {
     start: u64,
@@ -157,6 +127,7 @@ pub struct ElfSymbolIterator<'a> {
     section_str_offset: u64,
 
     load_header: ElfLoadHeader,
+    system_page_mask: u64,
 
     entry_count: u64,
     entry_index: u64,
@@ -165,7 +136,7 @@ pub struct ElfSymbolIterator<'a> {
 }
 
 impl<'a> ElfSymbolIterator<'a> {
-    pub fn new(file: File, load_header: ElfLoadHeader) -> Self {
+    pub fn new(file: File, load_header: ElfLoadHeader, system_page_size: u64) -> Self {
 
         Self {
             phantom: std::marker::PhantomData,
@@ -175,10 +146,15 @@ impl<'a> ElfSymbolIterator<'a> {
             section_offsets: Vec::new(),
             section_str_offset: 0,
             load_header: load_header,
+            system_page_mask: Self::page_size_to_mask(system_page_size),
             entry_count: 0,
             entry_index: 0,
             reset: true,
         }
+    }
+
+    fn page_size_to_mask(page_size: u64) -> u64 {
+        !((page_size - 1) as u64)
     }
 
     pub fn reset(&mut self) {
@@ -262,6 +238,7 @@ impl<'a> ElfSymbolIterator<'a> {
                 self.entry_index,
                 self.section_str_offset,
                 &self.load_header,
+                self.system_page_mask,
                 symbol);
 
             self.entry_index+=1;
@@ -302,6 +279,7 @@ pub fn get_str(
 fn get_symbols32(
     reader: &mut (impl Read + Seek),
     load_header: &ElfLoadHeader,
+    system_page_mask : u64,
     metadata: &SectionMetadata,
     count: u64,
     str_offset: u64,
@@ -315,6 +293,7 @@ fn get_symbols32(
             i,
             str_offset,
             load_header,
+            system_page_mask,
             &mut symbol).is_err() {
                 continue;
         }
@@ -327,11 +306,12 @@ fn get_symbols32(
 
 fn symbol_rva(
     value: u64,
-    load_header: &ElfLoadHeader) -> u64 {
+    load_header: &ElfLoadHeader,
+    system_page_mask: u64) -> u64 {
 
     // The load header values must be page aligned.
-    assert!(load_header.p_vaddr() & system_page_mask() == load_header.p_vaddr());
-    assert!(load_header.p_offset() & system_page_mask() == load_header.p_offset());
+    assert!(load_header.p_vaddr() & system_page_mask == load_header.p_vaddr());
+    assert!(load_header.p_offset() & system_page_mask == load_header.p_offset());
     (value - load_header.p_vaddr()) + load_header.p_offset()
 }
 
@@ -341,6 +321,7 @@ fn get_symbol32(
     sym_index: u64,
     str_offset: u64,
     load_header: &ElfLoadHeader,
+    system_page_mask: u64,
     symbol: &mut ElfSymbol) -> Result<(), Error> {
     let mut sym = ElfSymbol32::default();
     let pos = metadata.offset + (sym_index * metadata.entry_size);
@@ -351,7 +332,7 @@ fn get_symbol32(
         return Err(Error::new(std::io::ErrorKind::InvalidData, "Invalid symbol"));
     }
 
-    symbol.start = symbol_rva(sym.st_value as u64, load_header);
+    symbol.start = symbol_rva(sym.st_value as u64, load_header, system_page_mask);
     symbol.end = symbol.start + (sym.st_size as u64 - 1);
     let str_pos = sym.st_name as u64 + str_offset;
 
@@ -364,6 +345,7 @@ fn get_symbol32(
 fn get_symbols64(
     reader: &mut (impl Read + Seek),
     load_header: &ElfLoadHeader,
+    system_page_mask: u64,
     metadata: &SectionMetadata,
     count: u64,
     str_offset: u64,
@@ -377,6 +359,7 @@ fn get_symbols64(
             i,
             str_offset,
             load_header,
+            system_page_mask,
             &mut symbol).is_err() {
                 continue;
         }
@@ -393,6 +376,7 @@ fn get_symbol64(
     sym_index: u64,
     str_offset: u64,
     load_header: &ElfLoadHeader,
+    system_page_mask: u64,
     symbol: &mut ElfSymbol) -> Result<(), Error> {
     let mut sym = ElfSymbol64::default();
     let pos = metadata.offset + (sym_index * metadata.entry_size);
@@ -403,7 +387,7 @@ fn get_symbol64(
         return Err(Error::new(std::io::ErrorKind::InvalidData, "Invalid symbol"));
     }
 
-    symbol.start = symbol_rva(sym.st_value as u64, load_header);
+    symbol.start = symbol_rva(sym.st_value as u64, load_header, system_page_mask);
     symbol.end = symbol.start + (sym.st_size - 1);
     let str_pos = sym.st_name as u64 + str_offset;
 
@@ -446,6 +430,7 @@ fn demangle_symbol(
 pub fn get_symbols(
     reader: &mut (impl Read + Seek),
     load_header: &ElfLoadHeader,
+    system_page_mask: u64,
     metadata: &Vec<SectionMetadata>,
     mut callback: impl FnMut(&ElfSymbol)) -> Result<(), Error> {
     let mut offsets: Vec<u64> = Vec::new();
@@ -466,10 +451,10 @@ pub fn get_symbols(
 
         match m.class {
             ELFCLASS32 => {
-                get_symbols32(reader, load_header, m, count, str_offset, &mut callback)?;
+                get_symbols32(reader, load_header, system_page_mask, m, count, str_offset, &mut callback)?;
             },
             ELFCLASS64 => {
-                get_symbols64(reader, load_header, m, count, str_offset, &mut callback)?;
+                get_symbols64(reader, load_header, system_page_mask, m, count, str_offset, &mut callback)?;
             },
             _ => {
                 /* Unknown, no symbols */
@@ -486,13 +471,14 @@ pub fn get_symbol(
     sym_index: u64,
     str_offset: u64,
     load_header: &ElfLoadHeader,
+    system_page_mask : u64,
     symbol: &mut ElfSymbol) -> Result<(), Error> {
     match metadata.class {
         ELFCLASS32 => {
-            return get_symbol32(reader, metadata, sym_index, str_offset, load_header, symbol);
+            return get_symbol32(reader, metadata, sym_index, str_offset, load_header, system_page_mask, symbol);
         },
         ELFCLASS64 => {
-            return get_symbol64(reader, metadata, sym_index, str_offset, load_header, symbol);
+            return get_symbol64(reader, metadata, sym_index, str_offset, load_header, system_page_mask, symbol);
         }
         _ => {
             /* Unknown, no symbols */
@@ -1280,13 +1266,16 @@ mod tests {
         /* Get load header */
         let load_header = elf::get_load_header(&mut file).unwrap();
 
+        /* Get the system page mask */
+        let system_page_mask = system_page_mask();
+
         /* Get Dyn and Function Symbols */
         get_section_metadata(&mut file, None, SHT_SYMTAB, &mut sections).unwrap();
         get_section_metadata(&mut file, None, SHT_DYNSYM, &mut sections).unwrap();
 
         let mut found = false;
 
-        get_symbols(&mut file, &load_header, &sections, |symbol| {
+        get_symbols(&mut file, &load_header, system_page_mask, &sections, |symbol| {
             if symbol.name() == "malloc" {
                 println!("{} - {}: {}", symbol.start, symbol.end, symbol.name());
                 found = true;
@@ -1294,6 +1283,18 @@ mod tests {
         }).unwrap();
 
         assert!(found);
+    }
+
+    #[cfg(target_os = "linux")]
+    fn system_page_mask() -> u64 {
+        unsafe {
+            let page_size = libc::sysconf(libc::_SC_PAGESIZE);
+            if page_size > 0 {
+                !((page_size - 1) as u64)
+            } else {
+                panic!("Failed to get system page size via sysconf(_SC_PAGESIZE)");
+            }
+        }
     }
 
     #[test]
@@ -1363,21 +1364,5 @@ mod tests {
 
         assert!(elf::build_id_equals(&build_id_1, &build_id_2));
         assert!(!elf::build_id_equals(&build_id_1, &build_id_3));
-    }
-
-    #[test]
-    fn page_size_functions() {
-        // Test that system_page_size returns a reasonable value
-        let page_size = system_page_size();
-        assert!(page_size > 0);
-        assert!(page_size <= 65536); // Common range: 4KB to 64KB
-
-        // Test that system_page_mask is consistent with page_size
-        let page_mask = system_page_mask();
-        let expected_mask = !((page_size - 1) as u64);
-        assert_eq!(page_mask, expected_mask);
-
-        // Test that page size is a power of 2
-        assert_eq!(page_size & (page_size - 1), 0);
     }
 }


### PR DESCRIPTION
Fixes three issues found in ELF symbol resolution, which were causing incorrect symbols to be resolved for some binaries.

- The PT_LOAD header was being fetched from whichever file contained the symbols, but the PT_LOAD header values are only valid in the actual binary and not in sidecar symbol files.
- The PT_LOAD header values need to be page aligned when computing the file offsets of the symbol start and end values.
- Removed special handling for SHT_NOBITS (.bss) segments because it was breaking symbol resolution and is not used for function symbols.