### PR TITLE
Specify the Application Name in the Parser

### DIFF
--- a/record-trace/engine/src/commandline.rs
+++ b/record-trace/engine/src/commandline.rs
@@ -11,7 +11,7 @@ use std::process;
 use crate::export::{Exporter, NetTraceExporter, PerfViewExporter};
 
 #[derive(Parser)]
-#[command(version = crate_version!(), about, long_about = None)]
+#[command(name = "record-trace", version = crate_version!(), about, long_about = None)]
 struct Args {
     #[arg(long, help = "Output directory")]
     out: Option<String>,


### PR DESCRIPTION
This is required now that record-trace is split into multiple crates. Without this, `record-trace -v` shows the name of the application as "engine".