### PR TITLE
Enable uprobe/kprobe support for Linux

### DIFF
--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -1797,13 +1797,19 @@ impl ExportMachine {
         closure: impl FnMut() + 'static) {
         self.drop_closures.push(Box::new(closure));
     }
+
+    pub fn cleanup(&mut self) {
+        for closure in &mut self.drop_closures {
+            closure();
+        }
+
+        self.drop_closures.clear();
+    }
 }
 
 impl Drop for ExportMachine {
     fn drop(&mut self) {
-        for closure in &mut self.drop_closures {
-            closure();
-        }
+        self.cleanup();
     }
 }
 

--- a/one_collect/src/helpers/exporting/universal.rs
+++ b/one_collect/src/helpers/exporting/universal.rs
@@ -136,6 +136,13 @@ impl UniversalExporter {
             move || { now.elapsed() >= duration })
     }
 
+    pub fn cleanup(&mut self) {
+        /* Ensure drop hooks run if they haven't already */
+        for mut hook in self.drop_hooks.drain(..) {
+            hook();
+        }
+    }
+
     pub fn parse_until(
         mut self,
         name: &str,

--- a/one_collect/src/scripting/mod.rs
+++ b/one_collect/src/scripting/mod.rs
@@ -231,6 +231,10 @@ impl ScriptEngine {
             }
         }
     }
+
+    pub fn cleanup_task(&mut self) -> Box<dyn FnMut()> {
+        self.os.cleanup_task()
+    }
 }
 
 #[cfg(test)]

--- a/one_collect/src/scripting/os/linux.rs
+++ b/one_collect/src/scripting/os/linux.rs
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use crate::os::system_page_size;
 use crate::tracefs::TraceFS;
 use crate::scripting::ScriptEvent;
+use crate::event::Event;
+use crate::page_size_to_mask;
 use crate::Writable;
 
 use rhai::{Engine, EvalAltResult};
@@ -26,26 +29,98 @@ pub(crate) fn version() -> (u16, u16) {
     (major, minor)
 }
 
-#[derive(Default)]
 pub struct OSScriptEngine {
+    probe_cleanups: Writable<Vec<String>>,
+}
+
+impl Default for OSScriptEngine {
+    fn default() -> Self {
+        Self {
+            probe_cleanups: Writable::new(Vec::new()),
+        }
+    }
 }
 
 impl OSScriptEngine {
+    fn event_from_probe(
+        tracefs: Writable<std::io::Result<TraceFS>>,
+        system: &str,
+        name: &str,
+        command: &str) -> anyhow::Result<Event> {
+        match tracefs.borrow().as_ref() {
+            Ok(tracefs) => {
+                match tracefs.dynamic_event_command(&command) {
+                    Ok(()) => {
+                        match tracefs.find_event(&system, &name) {
+                            Ok(event) => { Ok(event.into()) },
+                            Err(_) => {
+                                anyhow::bail!("Event \"{}/{}\" not found.", &system, &name);
+                            },
+                        }
+                    },
+                    Err(err) => {
+                        anyhow::bail!("Dynamic events parsing error: {}", err);
+                    }
+                }
+            },
+            Err(err) => {
+                anyhow::bail!("TraceFS is not accessible: {}", err);
+            }
+        }
+    }
+
+    fn elf_symbol_offset(
+        path: &str,
+        name: &str) -> anyhow::Result<u64> {
+        use ruwind::elf::{self, SHT_DYNSYM, SHT_SYMTAB};
+        use std::fs::File;
+
+        let mut file = File::open(path)?;
+        let mut sections = Vec::new();
+        let page_size = system_page_size();
+        let page_mask = page_size_to_mask(page_size);
+
+        let load_header = elf::get_load_header(&mut file)?;
+
+        /* Get symbol sections */
+        elf::get_section_metadata(&mut file, None, SHT_SYMTAB, &mut sections)?;
+        elf::get_section_metadata(&mut file, None, SHT_DYNSYM, &mut sections)?;
+
+        let mut offset = None;
+
+        /* Get symbols from those sections and pass to caller */
+        elf::get_symbols(
+            &mut file,
+            &load_header,
+            page_mask,
+            &sections,
+            |symbol| {
+                if symbol.name() == name {
+                    offset = Some(symbol.start());
+            }
+        })?;
+
+        match offset {
+            Some(offset) => { Ok(offset) },
+            None =>{
+                anyhow::bail!("Symbol \"{}\" not found in {}", name, path);
+            }
+        }
+    }
+
     pub fn enable(
         &mut self,
         engine: &mut Engine) {
         /* Use single tracefs for all function invocations */
-        let tracefs = match TraceFS::open() {
-            Ok(tracefs) => { Some(tracefs) },
-            Err(_) => { None },
-        };
+        let tracefs = Writable::new(TraceFS::open());
 
-        let fn_tracefs = Writable::new(tracefs);
+        let fn_tracefs = tracefs.clone();
 
         engine.register_fn(
             "event_from_tracefs",
             move |system: String, name: String| -> Result<ScriptEvent, Box<EvalAltResult>> {
-                if let Some(tracefs) = fn_tracefs.borrow().as_ref() {
+            match fn_tracefs.borrow().as_ref() {
+                Ok(tracefs) => {
                     match tracefs.find_event(&system, &name) {
                         Ok(event) => { Ok(event.into()) },
                         Err(_) => {
@@ -53,9 +128,150 @@ impl OSScriptEngine {
                                 "Event \"{}/{}\" not found.", &system, &name).into())
                         },
                     }
-                } else {
-                    Err("TraceFS is not accessible (check permissions).".into())
+                },
+                Err(err) => {
+                    Err(format!("TraceFS is not accessible: {}", err).into())
                 }
-            });
+            }
+        });
+
+        let fn_tracefs = tracefs.clone();
+        let fn_cleanup = self.probe_cleanups.clone();
+
+        engine.register_fn(
+            "event_from_uprobe",
+            move |
+            system: String,
+            name: String,
+            path: String,
+            symbol: String,
+            args: String| -> Result<ScriptEvent, Box<EvalAltResult>> {
+            let offset = match Self::elf_symbol_offset(&path, &symbol) {
+                Ok(offset) => { offset },
+                Err(err) => { return Err(format!("Error: {}", err).into()); },
+            };
+
+            let command = format!(
+                "p:{}/{} {}:0x{:x} {}",
+                &system,
+                &name,
+                &path,
+                offset,
+                &args);
+
+            match Self::event_from_probe(fn_tracefs.clone(), &system, &name, &command) {
+                Ok(event) => {
+                    fn_cleanup.borrow_mut().push(
+                        format!("-:{}/{}", system, name));
+
+                    Ok(event.into())
+                },
+                Err(err) => { Err(format!("Error: {}", err).into()) },
+            }
+        });
+
+        let fn_tracefs = tracefs.clone();
+        let fn_cleanup = self.probe_cleanups.clone();
+
+        engine.register_fn(
+            "event_from_ret_uprobe",
+            move |
+            system: String,
+            name: String,
+            path: String,
+            symbol: String,
+            args: String| -> Result<ScriptEvent, Box<EvalAltResult>> {
+            let offset = match Self::elf_symbol_offset(&path, &symbol) {
+                Ok(offset) => { offset },
+                Err(err) => { return Err(format!("Error: {}", err).into()); },
+            };
+
+            let command = format!(
+                "r:{}/{} {}:0x{:x} {}",
+                &system,
+                &name,
+                &path,
+                offset,
+                &args);
+
+            match Self::event_from_probe(fn_tracefs.clone(), &system, &name, &command) {
+                Ok(event) => {
+                    fn_cleanup.borrow_mut().push(
+                        format!("-:{}/{}", system, name));
+
+                    Ok(event.into())
+                },
+                Err(err) => { Err(format!("Error: {}", err).into()) },
+            }
+        });
+
+        let fn_tracefs = tracefs.clone();
+        let fn_cleanup = self.probe_cleanups.clone();
+
+        engine.register_fn(
+            "event_from_kprobe",
+            move |
+            system: String,
+            name: String,
+            symbol: String,
+            args: String| -> Result<ScriptEvent, Box<EvalAltResult>> {
+            let command = format!(
+                "p:{}/{} {} {}",
+                &system,
+                &name,
+                &symbol,
+                &args);
+
+            match Self::event_from_probe(fn_tracefs.clone(), &system, &name, &command) {
+                Ok(event) => {
+                    fn_cleanup.borrow_mut().push(
+                        format!("-:{}/{}", system, name));
+
+                    Ok(event.into())
+                },
+                Err(err) => { Err(format!("Error: {}", err).into()) },
+            }
+        });
+
+        let fn_tracefs = tracefs.clone();
+        let fn_cleanup = self.probe_cleanups.clone();
+
+        engine.register_fn(
+            "event_from_ret_kprobe",
+            move |
+            system: String,
+            name: String,
+            symbol: String,
+            args: String| -> Result<ScriptEvent, Box<EvalAltResult>> {
+            let command = format!(
+                "r:{}/{} {} {}",
+                &system,
+                &name,
+                &symbol,
+                &args);
+
+            match Self::event_from_probe(fn_tracefs.clone(), &system, &name, &command) {
+                Ok(event) => {
+                    fn_cleanup.borrow_mut().push(
+                        format!("-:{}/{}", system, name));
+
+                    Ok(event.into())
+                },
+                Err(err) => { Err(format!("Error: {}", err).into()) },
+            }
+        });
+    }
+
+    pub fn cleanup_task(&mut self) -> Box<dyn FnMut()> {
+        let probe_cleanups = self.probe_cleanups.clone();
+
+        Box::new(move || {
+            /* Cleanup any probes with best effort */
+            if let Ok(tracefs) = TraceFS::open() {
+                for cleanup in probe_cleanups.borrow().iter() {
+                    _ = tracefs.dynamic_event_command(&cleanup);
+                }
+            }
+        })
     }
 }

--- a/one_collect/src/scripting/os/windows.rs
+++ b/one_collect/src/scripting/os/windows.rs
@@ -137,4 +137,9 @@ impl OSScriptEngine {
             Ok(event.into())
         });
     }
+
+    pub fn cleanup_task(&mut self) -> Box<dyn FnMut()> {
+        /* Nothing */
+        Box::new(|| {})
+    }
 }

--- a/one_collect/src/tracefs.rs
+++ b/one_collect/src/tracefs.rs
@@ -287,6 +287,32 @@ impl TraceFS {
             &mut reader)
     }
 
+    /// Runs a command on the dynamic_events tracefs file.
+    ///
+    /// # Arguments
+    ///
+    /// * `command` - A string containing the command to run.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` which is `Ok` if the command is successfully parsed, and `Err` otherwise.
+    pub fn dynamic_event_command(
+        &self,
+        command: &str) -> Result<()> {
+        let mut path_buf = PathBuf::new();
+
+        path_buf.push(&self.root);
+        path_buf.push("dynamic_events");
+
+        let mut file = File::options()
+            .append(true)
+            .open(path_buf)?;
+
+        file.write_all(command.as_bytes())?;
+
+        Ok(())
+    }
+
     fn register_uprobe_full(
         &self,
         probe_type: &str,

--- a/record-trace/engine/src/recorder.rs
+++ b/record-trace/engine/src/recorder.rs
@@ -275,12 +275,15 @@ impl Recorder {
 
         if let Err(e) = format.run(&mut exporter, &self.args) {
             self.output.error(&format!("Error: {}", e));
+            exporter.cleanup();
             return 1;
         }
 
         self.output.normal("Finished recording trace.");
         self.output.normal(
             &format!("Trace written to {}", self.args.output_path().display()));
+
+        exporter.cleanup();
 
         0
     }


### PR DESCRIPTION
Linux has uprobe and kprobes (both of which have enter and exit probes) which we need to support. This pull request enables this functionality at the script level, so scripts can easily register these probes and upon collection ending, they automatically get cleaned up (deleted) from tracefs. Ensuring things get cleaned up is covered in this pull request as well, which is the bulk of the changes.

Closes #157, these are the new script methods that can be utilized for that:
```
event_from_uprobe(
            system: String,
            name: String,
            path: String,
            symbol: String,
            args: String)

event_from_ret_uprobe(
            system: String,
            name: String,
            path: String,
            symbol: String,
            args: String)

event_from_kprobe(
            system: String,
            name: String,
            symbol: String,
            args: String)

 event_from_ret_kprobe(
            system: String,
            name: String,
            symbol: String,
            args: String)
```