### PR TITLE
Add GitHub Agent Metadata

### DIFF
--- a/.github/agents/tracing-expert.md
+++ b/.github/agents/tracing-expert.md
@@ -1,4 +1,12 @@
-# Tracing Expert Agent
+---
+# Fill in the fields below to create a basic custom agent for your repository.
+# The Copilot CLI can be used for local testing: https://gh.io/customagents/cli
+# To make this agent available, merge this file into the default repository branch.
+# For format details, see: https://gh.io/customagents/config
+
+name: Tracing Expert
+description: Knows how to add tracing statements that follow one-collect's tracing guidelines.
+---
 
 ## Role
 You are an expert at adding appropriate tracing messages to the one-collect codebase using the Rust `tracing` crate. Your expertise is in identifying where logging should be added and ensuring it follows established patterns and guidelines.


### PR DESCRIPTION
Update tracing-expert.md to add the GitHub agent required metadata.