### PR TITLE
Detect DotNet processes with IPC mmap operation

### DIFF
--- a/one_collect/src/helpers/callstack/os/linux.rs
+++ b/one_collect/src/helpers/callstack/os/linux.rs
@@ -533,7 +533,7 @@ impl CallstackHelp for RingBufSessionBuilder {
                 let events = builder
                     .take_kernel_events()
                     .unwrap_or_else(RingBufBuilder::for_kernel)
-                    .with_mmap_records()
+                    .with_executable_mmap_records()
                     .with_comm_records()
                     .with_task_records();
 

--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -1418,11 +1418,23 @@ impl DotNetHelp for RingBufSessionBuilder {
         };
 
         self.with_hooks(
-            move |_builder| {
-                /* Nothing to build */
+            move |builder| {
+                /* Enable all mmap records (including non-executable) for dotnet helper
+                 * to capture dotnet processes that emit the /memfd:dotnet_ipc_created mapping. */
+                let kernel = builder
+                    .take_kernel_events()
+                    .unwrap_or_else(RingBufBuilder::for_kernel)
+                    .with_all_mmap_records();
+
+                builder.replace_kernel_events(kernel);
             },
 
             move |session| {
+                /* Enable capture of all mmap records (including non-executable) during environment
+                 * capture to discover dotnet processes that have created the /memfd:dotnet_ipc_created mapping. */
+                session.capture_env_options_mut()
+                    .with_all_mmaps();
+
                 if perf_maps {
                     /* Perf map support */
                     let event = session.mmap_event();

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -1528,7 +1528,7 @@ impl ExportBuilderHelp for RingBufSessionBuilder {
         let mut builder = self;
 
         let mut kernel = RingBufBuilder::for_kernel()
-            .with_mmap_records()
+            .with_executable_mmap_records()
             .with_comm_records()
             .with_task_records();
 

--- a/one_collect/src/perf_event/mod.rs
+++ b/one_collect/src/perf_event/mod.rs
@@ -29,6 +29,22 @@ pub use rb::source::RingBufSessionBuilder;
 pub use rb::{RingBufOptions, RingBufBuilder};
 pub use rb::cpu_count;
 
+#[derive(Default)]
+pub(crate) struct CaptureEnvironmentOptions {
+    all_mmaps: bool,
+}
+
+impl CaptureEnvironmentOptions {
+    pub fn with_all_mmaps(&mut self) -> &mut Self {
+        self.all_mmaps = true;
+        self
+    }
+
+    pub fn all_mmaps(&self) -> bool {
+        self.all_mmaps
+    }
+}
+
 static EMPTY: &[u8] = &[];
 
 #[derive(Default)]
@@ -230,6 +246,7 @@ pub struct PerfSession {
 
     /* Options */
     read_timeout: Duration,
+    capture_env_options: CaptureEnvironmentOptions,
 
     /* Events */
     cpu_profile_event: Event,
@@ -331,6 +348,7 @@ impl PerfSession {
 
             /* Options */
             read_timeout: Duration::from_millis(15),
+            capture_env_options: CaptureEnvironmentOptions::default(),
 
             /* Events */
             cpu_profile_event: Event::new(0, "__cpu_profile".into()),
@@ -491,6 +509,10 @@ impl PerfSession {
         &mut self,
         timeout: Duration) {
         self.read_timeout = timeout;
+    }
+
+    pub(crate) fn capture_env_options_mut(&mut self) -> &mut CaptureEnvironmentOptions {
+        &mut self.capture_env_options
     }
 
     pub fn create_bpf_files(
@@ -1198,6 +1220,7 @@ impl PerfSession {
 
         let attributes = RingBufBuilder::common_attributes();
         let enabled = self.source_enabled;
+        let captures_all = self.capture_env_options.all_mmaps();
         let mut event_data: Vec<u8> = Vec::new();
         let mut full_data: Vec<u8> = Vec::new();
 
@@ -1209,7 +1232,13 @@ impl PerfSession {
         let mut module_count = 0;
 
         procfs::iter_modules(move |pid, module| {
-            if !module.is_exec() || module.path.is_none() {
+            // Skip modules without paths
+            if module.path.is_none() {
+                return;
+            }
+
+            // Filter non-executable mappings unless capturing all mmaps
+            if !captures_all && !module.is_exec() {
                 return;
             }
 

--- a/one_collect/src/perf_event/rb/mod.rs
+++ b/one_collect/src/perf_event/rb/mod.rs
@@ -394,10 +394,21 @@ impl RingBufBuilder<Bpf> {
 }
 
 impl RingBufBuilder<Kernel> {
-    pub fn with_mmap_records(&self) -> Self {
+    pub fn with_executable_mmap_records(&self) -> Self {
         let mut attributes = self.attributes;
 
         attributes.flags |= FLAG_MMAP | FLAG_MMAP2;
+
+        Self {
+            attributes,
+            _type: self._type,
+        }
+    }
+
+    pub fn with_all_mmap_records(&self) -> Self {
+        let mut attributes = self.attributes;
+
+        attributes.flags |= FLAG_MMAP | FLAG_MMAP2 | FLAG_MMAP_DATA;
 
         Self {
             attributes,
@@ -1117,7 +1128,7 @@ mod tests {
         rb_head.open(pid).unwrap();
 
         let kernel = RingBufBuilder::for_kernel()
-            .with_mmap_records();
+            .with_executable_mmap_records();
 
         let page_count = 1;
         let _reader = rb_head.create_reader(page_count).unwrap();

--- a/one_collect/src/perf_event/rb/source.rs
+++ b/one_collect/src/perf_event/rb/source.rs
@@ -1109,7 +1109,7 @@ mod tests {
     #[test]
     fn config() {
         let kernel = RingBufBuilder::for_kernel()
-            .with_mmap_records()
+            .with_executable_mmap_records()
             .with_comm_records()
             .with_task_records()
             .with_cswitch_records();


### PR DESCRIPTION
One-collect currently depends upon the existence of an mmap call in the .NET runtime for a mapping called doublemapper in order to detect that the process is a .NET process.  This is fragile as doublemapper is an implementation detail used by the W^X implementation.

Rather than depending on this mapping, depend upon the existence of a mapping called dotnet_ipc_created, which will be created by the .NET runtime once the IPC channel has been created.

For the purposes of backwards compatibility, we'll keep checking for doublemapper, though ideally the new mapping is backported.

Fixes #226 