### PR TITLE
Perf: Drain session after disabling

### DIFF
--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -1630,6 +1630,9 @@ impl UniversalExporterOSHooks for UniversalExporter {
             session.disable()?;
             exporter.borrow_mut().mark_end();
 
+            /* Parse any remaining data. */
+            session.parse_all()?;
+
             self.run_parsed_hooks(&exporter)?;
 
             Ok(())


### PR DESCRIPTION
The universal session currently parses until told to stop, then disables the ring buffers. This can potentially skip data that was in the buffer(s) at the time it was told to stop.

Add a call to parse_all() after disabling the ring buffers to ensure all data within the buffers after disabling is parsed out. This ensures the output reflects all data up until the disable call.