### PR TITLE
ruwind: try RBP chain walk before linear prolog scan

### DIFF
--- a/ruwind/src/x64unwinder.rs
+++ b/ruwind/src/x64unwinder.rs
@@ -115,6 +115,7 @@ impl Unwinder {
         result: &mut UnwindResult) -> Option<u64> {
 
         let cfa = self.registers[REG_RSP];
+        let rbp = self.registers[REG_RBP];
         let len = stack_data.len();
 
         /* Ensure valid enough to start scan */
@@ -127,6 +128,55 @@ impl Unwinder {
 
         /* Limit range to stack size at stack location */
         let max_cfa = cfa + len as u64;
+
+        /*
+         * Try walking the RBP frame pointer chain first.
+         *
+         * Many compilers and runtimes maintain an RBP chain on x64 where
+         * [rbp] = caller's saved RBP and [rbp+8] = return address. If a
+         * function does not push RBP, it simply preserves the register
+         * and is skipped in the chain (equivalent to inlining).
+         *
+         * We follow the chain looking for a link where [rbp+8] is a valid
+         * code address. If [rbp+8] is not valid, we follow [rbp] to the
+         * next chain link. If the chain is absent or corrupted (e.g. RBP
+         * is used as a general-purpose register), the guard checks below
+         * (alignment, forward progress, bounds) will break out and we
+         * fall back to the existing linear scan.
+         */
+        let max_chain_depth = 16;
+        let mut chain_rbp = rbp;
+
+        for _depth in 0..max_chain_depth {
+            let saved_rbp = match Unwinder::stack_value(self.rsp, chain_rbp, 0, stack_data) {
+                Some(v) => v,
+                None => break,
+            };
+
+            let ret_addr = match Unwinder::stack_value(self.rsp, chain_rbp, 8, stack_data) {
+                Some(v) => v,
+                None => break,
+            };
+
+            if process.find(ret_addr).is_some() {
+                trace!("RBP chain walk successful: chain_rbp={:#x}, saved_rbp={:#x}, ret_addr={:#x}, depth={}", chain_rbp, saved_rbp, ret_addr, _depth);
+                self.registers[REG_RSP] = chain_rbp + 16;
+                self.registers[REG_RBP] = saved_rbp;
+                return Some(ret_addr);
+            }
+
+            /* [rbp+8] wasn't a valid return address — follow the chain */
+            if saved_rbp <= chain_rbp || saved_rbp > max_cfa || saved_rbp & 0x7 != 0 {
+                break;
+            }
+
+            chain_rbp = saved_rbp;
+        }
+
+        /*
+         * RBP chain walk didn't find a frame. Fall back to scanning
+         * consecutive stack slots for (stack_address, code_address) pairs.
+         */
 
         /* Determine offset and limit read offset */
         let mut offset = (cfa - self.rsp) as usize;


### PR DESCRIPTION
Fixes #235 

The prolog scanner's linear scan heuristic can produce false positive matches for code without DWARF unwind data, causing broken CPU stacks where intermediate frames are skipped. This change adds an RBP frame pointer chain walk before the existing linear scan, recovering frames that were previously lost.

When profiling applications with JIT'd or dynamically generated code (which lives in anonymous memory without .eh_frame DWARF data), CPU stacks can show gaps where intermediate frames are missing. (e.g. a 10-level call chain produces only 6 frames with a gap in the middle)

The linear prolog scanner scans consecutive stack slots for (stack_address, code_address) pairs and accepts the first match. When the stack contains values that coincidentally pass both checks before the real frame data, the scanner accepts a false match and skips intermediate frames.

This PR proposes adding RBP frame pointer chain walking to the unwinder:
   1. Read [rbp] for the saved RBP and [rbp+8] for the return address
   2. If [rbp+8] is a valid code address, accept it as the next frame
   3. If not, follow [rbp] to the next chain link
   4. If the chain is absent or corrupted, fall back to the existing linear scan

Guard rails: alignment check, forward-progress check, bounds check, and a 16-link depth limit ensure the chain walk terminates safely for code that doesn't use frame pointers.

### Testing
Tested with an application that has a 10-level call chain in JIT'd code:
   - Without fix: 6 total frames, only the leaf function visible, false match gap present
   - With fix: 20 total frames, all intermediate functions recovered, no gap

### Scope
   - Purely additive -- the existing linear scan is preserved as a fallback
   - The chain walk only runs inside unwind_prolog(), which is only called for anonymous memory modules without DWARF data. File-backed modules with .eh_frame use DWARF and are unaffected
   - Many compilers and runtimes maintain RBP chains on x64. For code that doesn't, the chain walk should fail safely and fallback to the linear scan as before this change