### PR TITLE
Fix OpenAt double-close and add perf map diagnostic logging

### DIFF
--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -145,17 +145,22 @@ impl PerfMapContext {
                     warn!("Failed to write to diagnostic socket: pid={}, nspid={}, error={}", self.pid, self.nspid, e);
                     anyhow::bail!("Failed to write to diagnostic socket: {}", e);
                 }
-                sock.read_exact(&mut result)?;
+                if let Err(e) = sock.read_exact(&mut result) {
+                    warn!("Failed to read diagnostic socket response: pid={}, nspid={}, error={}", self.pid, self.nspid, e);
+                    anyhow::bail!("Failed to read diagnostic socket response: {}", e);
+                }
 
                 let result = u32::from_le_bytes(result[20..].try_into()?);
 
                 if result != 0 {
-                    anyhow::bail!("Failed with error {}.", result);
+                    warn!("Diagnostic socket returned error: pid={}, nspid={}, result={}", self.pid, self.nspid, result);
+                    anyhow::bail!("Diagnostic socket returned error: {}", result);
                 }
 
+                info!("Perf map enabled: pid={}, nspid={}", self.pid, self.nspid);
                 Ok(())
             },
-            None => { anyhow::bail!("Not found."); },
+            None => { anyhow::bail!("Diagnostic socket not found: pid={}, nspid={}", self.pid, self.nspid); },
         }
     }
 
@@ -476,23 +481,39 @@ impl PerfMapTracker {
 
             let nspid = procfs::ns_pid(&mut path_buf, pid).unwrap_or(pid);
 
-            if let Ok(proc) = PerfMapContext::new(pid, nspid) {
-                if let Ok(has_environ) = proc.has_perf_map_environ() {
-                    if has_environ {
-                        continue;
-                    }
+            let proc = match PerfMapContext::new(pid, nspid) {
+                Ok(proc) => proc,
+                Err(e) => {
+                    warn!("PerfMapTracker: failed to create PerfMapContext: pid={}, nspid={}, error={}", pid, nspid, e);
+                    continue;
+                }
+            };
 
-                    /* Always try to disable in case it was left on */
-                    let _ = proc.disable_perf_map();
+            match proc.has_perf_map_environ() {
+                Ok(true) => {
+                    debug!("PerfMapTracker: skipping pid={}, nspid={}, already has perf map env var", pid, nspid);
+                    continue;
+                }
+                Ok(false) => { }
+                Err(e) => {
+                    warn!("PerfMapTracker: failed to read perf map environ: pid={}, nspid={}, error={}", pid, nspid, e);
+                }
+            }
 
-                    /* Enable until the thread is done */
-                    if proc.enable_perf_map().is_ok() {
-                        /* Save context for later */
-                        arc.lock().unwrap().push(proc);
+            /* Always try to disable in case it was left on */
+            let _ = proc.disable_perf_map();
 
-                        /* Ensure we don't enable it again */
-                        pids.insert(pid);
-                    }
+            /* Enable until the thread is done */
+            match proc.enable_perf_map() {
+                Ok(()) => {
+                    /* Save context for later */
+                    arc.lock().unwrap().push(proc);
+
+                    /* Ensure we don't enable it again */
+                    pids.insert(pid);
+                }
+                Err(e) => {
+                    warn!("PerfMapTracker: failed to enable perf map: pid={}, nspid={}, error={}", pid, nspid, e);
                 }
             }
         }

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::fs::File;
 use std::fmt::Write;
 use std::io::BufReader;
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 
 use crate::{ReadOnly, Writable};
 use crate::event::DataFieldRef;
@@ -118,6 +118,7 @@ impl ExportProcessLinuxExt for ExportProcess {
         frames.clear();
 
         if self.os.root_fs.is_none() {
+            warn!("add_matching_elf_symbols: skipped, pid={}, no root_fs available", self.pid());
             return;
         }
 
@@ -157,7 +158,10 @@ impl ExportProcessLinuxExt for ExportProcess {
             // Get the dev node or continue.
             let dev_node = match map.node() {
                 Some(key) => key,
-                None => continue
+                None => {
+                    debug!("add_matching_elf_symbols: no dev_node for file={}, skipping", filename);
+                    continue
+                }
             };
 
             // If there is no metadata, then we can't load symbols.
@@ -171,6 +175,10 @@ impl ExportProcessLinuxExt for ExportProcess {
                     metadata,
                     SYMBOL_TYPE_ELF_SYMTAB | SYMBOL_TYPE_ELF_DYNSYM,
                     strings);
+
+                if sym_files.is_empty() {
+                    debug!("add_matching_elf_symbols: no symbol files found for file={}", filename);
+                }
 
                 for sym_file in sym_files {
 
@@ -1199,13 +1207,16 @@ impl OSExportMachine {
             let file = proc.open_file(&path_buf);
             path_buf.pop();
 
-            if file.is_err() {
-                info!("Perf-map file rejected: could not open file");
-                continue;
-            }
+            let file = match file {
+                Ok(f) => f,
+                Err(e) => {
+                    warn!("Unable to open perf-map file: pid={}, ns_pid={:?}, error={}", proc.pid(), ns_pid, e);
+                    continue;
+                }
+            };
 
             info!("Perf-map file accepted: file opened successfully");
-            let mut sym_reader = PerfMapSymbolReader::new(file.unwrap());
+            let mut sym_reader = PerfMapSymbolReader::new(file);
 
             proc.add_matching_anon_symbols(
                 &mut addrs,

--- a/one_collect/src/helpers/exporting/process.rs
+++ b/one_collect/src/helpers/exporting/process.rs
@@ -4,6 +4,8 @@
 use std::fs::File;
 use std::cell::OnceCell;
 
+use tracing::debug;
+
 use crate::intern::InternedCallstacks;
 
 use ruwind::{CodeSection, Unwindable};
@@ -852,6 +854,7 @@ impl ExportProcess {
         addrs.clear();
         frames.clear();
 
+        let pid = self.pid();
         for map in self.mappings.mappings_mut() {
             if !map.anon() {
                 continue;
@@ -865,6 +868,8 @@ impl ExportProcess {
                 Some(map));
 
             if addrs.is_empty() {
+                debug!("add_matching_anon_symbols: no unique IPs in anonymous mapping: pid={}, mapping_start={:#x}",
+                    pid, map.start());
                 continue;
             }
 

--- a/one_collect/src/openat.rs
+++ b/one_collect/src/openat.rs
@@ -4,16 +4,19 @@
 use std::fs::File;
 use std::ffi::CString;
 use std::path::Path;
+use std::sync::Arc;
 use tracing::debug;
 
 #[cfg(target_os = "linux")]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(target_os = "linux")]
-use std::os::fd::{RawFd, FromRawFd, IntoRawFd};
+use std::os::fd::{RawFd, FromRawFd, IntoRawFd, OwnedFd, AsRawFd};
 
 /* Required for cross-platform docs */
 #[cfg(not(target_os = "linux"))]
 struct RawFd {}
+#[cfg(not(target_os = "linux"))]
+struct OwnedFd {}
 
 /// `DupFd` is a wrapper around a raw file descriptor.
 ///
@@ -59,9 +62,11 @@ impl DupFd {
 
 /// `OpenAt` provides a safe interface for opening and manipulating files relative to a directory file descriptor.
 ///
+/// Uses `Arc<OwnedFd>` for the underlying fd so that clones share ownership
+/// and the fd is only closed when the last clone is dropped.
 #[derive(Clone)]
 pub struct OpenAt {
-    fd: RawFd,
+    fd: Arc<OwnedFd>,
 }
 
 impl OpenAt {
@@ -74,7 +79,7 @@ impl OpenAt {
     /// * `Self`: A new `OpenAt` instance.
     pub fn new(dir: File) -> Self {
         Self {
-            fd: dir.into_raw_fd()
+            fd: Arc::new(OwnedFd::from(dir))
         }
     }
 
@@ -97,7 +102,7 @@ impl OpenAt {
 
         unsafe {
             let fd = libc::openat(
-                self.fd,
+                self.fd.as_raw_fd(),
                 path_bytes.as_ptr() as *const libc::c_char,
                 libc::O_RDONLY | libc::O_CLOEXEC);
 
@@ -130,7 +135,7 @@ impl OpenAt {
 
         unsafe {
             let result = libc::unlinkat(
-                self.fd,
+                self.fd.as_raw_fd(),
                 path.as_ptr() as *const libc::c_char,
                 0);
 
@@ -209,14 +214,5 @@ impl OpenAt {
 
         debug!("Found matching paths: path={:?}, count={}, prefix={}", path, paths.len(), prefix);
         Some(paths)
-    }
-}
-
-impl Drop for OpenAt {
-    /// Closes the directory file descriptor when the `OpenAt` struct is dropped.
-    fn drop(&mut self) {
-        unsafe {
-            libc::close(self.fd);
-        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where `OpenAt` file descriptors were invalidated after clone due to a double-close, and adds diagnostic logging to help diagnose cases where JIT symbols are missing from perf maps.

## Bug Fix: OpenAt double-close on clone

`OpenAt` derived `Clone` but also implemented `Drop` to close its raw fd. When cloned, both copies shared the same fd, and dropping one would close it out from under the other, causing `EBADF` errors during perf-map file resolution. Fixed by replacing the raw fd with `Arc<OwnedFd>` so that clones share ownership and the fd is only closed when the last reference is dropped.

## Diagnostic Logging

Added warn/info/debug logging at critical points in the perf map and symbol resolution pipeline:

**Perf map enablement (dotnet helper):**
- `enable_perf_map`: warn on socket read/write errors and IPC result errors with pid/nspid context. Info on success.
- `disable_perf_map`: warn on socket write errors.
- `worker_thread_proc`: warn on PerfMapContext creation, environ read, and enable failures. Debug when skipping already-enabled processes.

**Symbol resolution (exporting):**
- `resolve_perf_map_symbols`: warn when perf-map file cannot be opened, with pid/ns_pid/error context.
- `add_matching_anon_symbols`: debug when anonymous mappings have no matching stack IPs.
- `add_matching_symbols`: info when 0 symbols matched a mapping.
- `add_matching_elf_symbols`: warn when root_fs unavailable. Debug for missing dev_node and empty symbol file results.