### PR TITLE
ETW: Wire up Related/ActivityId to Exporting

### DIFF
--- a/one_collect/src/etw/mod.rs
+++ b/one_collect/src/etw/mod.rs
@@ -109,6 +109,19 @@ impl AncillaryData {
         }
     }
 
+    pub fn related_activity(&self) -> Option<Guid> {
+        if let Some(ext) = self.find_ext(
+            abi::EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID) {
+            unsafe {
+                if (*ext).DataSize == 16 {
+                    return Some(*((*ext).DataPtr as *const Guid));
+                }
+            }
+        }
+
+        None
+    }
+
     pub fn op_code(&self) -> u8 {
         match self.event {
             Some(event) => {

--- a/one_collect/src/helpers/exporting/os/windows.rs
+++ b/one_collect/src/helpers/exporting/os/windows.rs
@@ -164,13 +164,16 @@ impl ExportSamplerOSHooks for ExportSampler {
     fn os_event_activity_id(
         &self,
         _data: &EventData) -> anyhow::Result<Option<[u8; 16]>> {
-        Ok(None)
+        Ok(Some(self.os.ancillary.borrow().activity().to_bytes()))
     }
 
     fn os_event_related_activity_id(
         &self,
         _data: &EventData) -> anyhow::Result<Option<[u8; 16]>> {
-        Ok(None)
+        Ok(match self.os.ancillary.borrow().related_activity() {
+            Some(id) => { Some(id.to_bytes()) },
+            None => { None },
+        })
     }
 
     fn os_event_callstack(

--- a/one_collect/src/lib.rs
+++ b/one_collect/src/lib.rs
@@ -30,6 +30,10 @@ impl Guid {
             data4: (uuid as u64).to_be_bytes()
         }
     }
+
+    pub fn to_bytes(&self) -> [u8; 16] {
+        unsafe { std::mem::transmute(*self) }
+    }
 }
 
 pub mod event;


### PR DESCRIPTION
ETW supports ActivityId and RelatedActivityId for events on Windows. The exporting helper supports tracking both of these attributes by default. However, we have not wired up the ETW attributes to the exporting attributes.

Add necessary callbacks to read Related/ActivityId attributes from ETW Event structures when asked for by exporting.