### PR TITLE
ETW: Allow Provider Wide Events

### DIFF
--- a/one_collect/src/etw/abi.rs
+++ b/one_collect/src/etw/abi.rs
@@ -103,6 +103,7 @@ const PROCESS_TRACE_MODE_EVENT_RECORD: u32 = 268435456;
 const EVENT_FILTER_TYPE_PID: u32 = 0x80000004;
 const EVENT_FILTER_TYPE_EVENT_ID: u32 = 0x80000200;
 const EVENT_FILTER_TYPE_STACKWALK: u32 = 0x80001000;
+const EVENT_FILTER_TYPE_STACKWALK_LEVEL_KW: u32 = 0x80004000;
 
 pub const EVENT_ENABLE_PROPERTY_ENABLE_KEYWORD_0: u32 = 64u32;
 pub const EVENT_ENABLE_PROPERTY_ENABLE_SILOS: u32 = 1024u32;
@@ -162,6 +163,16 @@ pub fn wide_string(
 
 const SE_PRIVILEGE_ENABLED: u32 = 2;
 const TOKEN_ADJUST_PRIVILEGES: u32 = 32;
+
+#[repr(C)]
+#[allow(non_snake_case)]
+#[derive(Default)]
+struct EVENT_FILTER_LEVEL_KW {
+    pub MatchAnyKeyword: u64,
+    pub MatchAllKeyword: u64,
+    pub Level: u8,
+    pub FilterIn: u8,
+}
 
 #[repr(C, packed)]
 #[allow(non_snake_case)]
@@ -529,6 +540,7 @@ pub struct TraceEnable {
     keyword: u64,
     events: Vec<u16>,
     callstacks: Vec<u16>,
+    callstack_keyword: Option<u64>,
     custom_filter: Option<TraceFilter>,
 }
 
@@ -545,6 +557,7 @@ impl TraceEnable {
             keyword: 0,
             events: Vec::new(),
             callstacks: Vec::new(),
+            callstack_keyword: None,
             custom_filter: None,
         }
     }
@@ -562,6 +575,12 @@ impl TraceEnable {
     pub fn needs_rundown(&self) -> bool { self.rundown }
 
     pub fn ensure_rundown(&mut self) { self.rundown = true; }
+
+    pub fn ensure_callstack_keyword(
+        &mut self,
+        keyword: u64) {
+        self.callstack_keyword = Some(keyword);
+    }
 
     pub fn ensure_no_filtering(
         &mut self) {
@@ -674,6 +693,12 @@ impl TraceEnable {
             let mut pids = EVENT_FILTER_DESCRIPTOR::default();
             pids.Type = EVENT_FILTER_TYPE_PID;
 
+            let mut callstack_kw_filter = EVENT_FILTER_LEVEL_KW::default();
+            let mut callstack_kw = EVENT_FILTER_DESCRIPTOR::default();
+            callstack_kw.Type = EVENT_FILTER_TYPE_STACKWALK_LEVEL_KW;
+            callstack_kw.Filter = &callstack_kw_filter as *const EVENT_FILTER_LEVEL_KW as *const u8;
+            callstack_kw.Size = std::mem::size_of::<EVENT_FILTER_LEVEL_KW>() as u32;
+
             let mut filters = Vec::new();
 
             if let Some(custom) = &self.custom_filter {
@@ -704,6 +729,13 @@ impl TraceEnable {
 
                     filters.push(pids);
                 }
+            }
+
+            if let Some(callstack_keyword) = self.callstack_keyword {
+                callstack_kw_filter.FilterIn = 1;
+                callstack_kw_filter.MatchAnyKeyword = callstack_keyword;
+
+                filters.push(callstack_kw);
             }
 
             params.EnableProperty |= self.properties;

--- a/one_collect/src/etw/mod.rs
+++ b/one_collect/src/etw/mod.rs
@@ -122,6 +122,15 @@ impl AncillaryData {
         None
     }
 
+    pub fn id(&self) -> u16 {
+        match self.event {
+            Some(event) => {
+                unsafe { (*event).EventHeader.EventDescriptor.Id }
+            },
+            None => { 0 },
+        }
+    }
+
     pub fn op_code(&self) -> u8 {
         match self.event {
             Some(event) => {
@@ -221,6 +230,7 @@ type EventLookup = HashMap<usize, Vec<Event>, BuildHasherDefault<XxHash64>>;
 struct ProviderEvents {
     use_op_id: bool,
     events: EventLookup,
+    wide_events: Vec<Event>,
 }
 
 impl ProviderEvents {
@@ -228,6 +238,7 @@ impl ProviderEvents {
         Self {
             use_op_id: false,
             events: HashMap::default(),
+            wide_events: Vec::new(),
         }
     }
 
@@ -246,6 +257,8 @@ impl ProviderEvents {
         id: usize) -> Option<&mut Vec<Event>> {
         self.events.get_mut(&id)
     }
+
+    fn wide_events_mut(&mut self) -> &mut Vec<Event> { &mut self.wide_events }
 }
 
 pub struct SessionCallbackContext {
@@ -577,14 +590,29 @@ impl EtwSession {
 
         let callstacks = !event.has_no_callstack_flag();
 
-        let events = self.provider_events_mut(
-            provider,
-            lookup_provider,
-            ensure_provider,
-            event.id(),
-            callstacks);
+        if event.has_id_wild_card_flag() {
+            if provider != EMPTY_PROVIDER {
+                let enabler = self.enable_provider(provider);
 
-        events.push(event);
+                ensure_provider(enabler);
+
+                let events = self
+                    .providers
+                    .entry(provider)
+                    .or_insert_with(|| ProviderEvents::new());
+
+                events.wide_events_mut().push(event);
+            }
+        } else {
+            let events = self.provider_events_mut(
+                provider,
+                lookup_provider,
+                ensure_provider,
+                event.id(),
+                callstacks);
+
+            events.push(event);
+        }
     }
 
     pub fn add_kernel_callstack(
@@ -1153,68 +1181,76 @@ impl EtwSession {
             let cpu_index = event.ProcessorIndex;
 
             /* Find events by provider ID */
-            if let Some(events) = events.get_mut(&event.EventHeader.ProviderId) {
+            if let Some(provider_events) = events.get_mut(&event.EventHeader.ProviderId) {
                 /* Determine which ID for lookup */
-                let id: usize = match events.use_op_id() {
+                let id: usize = match provider_events.use_op_id() {
                     true => { event.EventHeader.EventDescriptor.Opcode.into() },
                     false => { event.EventHeader.EventDescriptor.Id.into() },
                 };
 
-                /* Find any registered closures for the event */
-                if let Some(events) = events.get_events_mut_if_exist(id) {
-                    /* Update ancillary data */
-                    ancillary.borrow_mut().event = Some(event);
+                let slice = event.user_data_slice();
 
-                    /* Process Event Data via Closures */
-                    let slice = event.user_data_slice();
+                let mut process_event = |event: &mut Event| {
+                    errors.clear();
 
-                    for event in events {
-                        errors.clear();
-
-                        if has_pid_filter {
-                            /*
-                             * Skip PID events via soft_pid filters:
-                             * Legacy Kernel ETW events do not have a stable
-                             * pid field. Events can register a software pid
-                             * reader to allow for this. These read the pid
-                             * from the actual event data vs the ancillary data.
-                             */
-                            if let Some(pid) = event.soft_pid(slice) {
-                                /* If we have a legacy PID, filter it */
-                                if pid != 0 && !pid_lookup.contains(&pid) {
-                                    /* Ignore if not in the set */
-                                    continue;
-                                }
-                            }
-                        }
-
-                        if has_cpu_filter && !event.has_no_cpu_mask_flag() {
-                            /* Skip events not on target CPUs */
-                            if let Some(target_cpus) = &target_cpus {
-                                if !target_cpus.contains(&cpu_index) {
-                                    return;
-                                }
-                            }
-                        }
-
-                        event.process(
-                            slice,
-                            slice,
-                            &mut errors);
-
-                        /* Log errors, if any */
-                        for error in &errors {
-                            if let Some(callback) = &error_callback {
-                                callback(event, error);
-                            } else {
-                                eprintln!("Error: Event '{}': {}", event.name(), error);
+                    if has_pid_filter {
+                        /*
+                         * Skip PID events via soft_pid filters:
+                         * Legacy Kernel ETW events do not have a stable
+                         * pid field. Events can register a software pid
+                         * reader to allow for this. These read the pid
+                         * from the actual event data vs the ancillary data.
+                         */
+                        if let Some(pid) = event.soft_pid(slice) {
+                            /* If we have a legacy PID, filter it */
+                            if pid != 0 && !pid_lookup.contains(&pid) {
+                                /* Ignore if not in the set */
+                                return;
                             }
                         }
                     }
 
-                    /* Clear ancillary data */
-                    ancillary.borrow_mut().event = None;
+                    if has_cpu_filter && !event.has_no_cpu_mask_flag() {
+                        /* Skip events not on target CPUs */
+                        if let Some(target_cpus) = &target_cpus {
+                            if !target_cpus.contains(&cpu_index) {
+                                return;
+                            }
+                        }
+                    }
+
+                    /* Process Event Data via Closures */
+                    event.process(
+                        slice,
+                        slice,
+                        &mut errors);
+
+                    /* Log errors, if any */
+                    for error in &errors {
+                        if let Some(callback) = &error_callback {
+                            callback(event, error);
+                        } else {
+                            eprintln!("Error: Event '{}': {}", event.name(), error);
+                        }
+                    }
+                };
+
+                /* Update ancillary data */
+                ancillary.borrow_mut().event = Some(event);
+
+                /* Find any registered closures for the event */
+                if let Some(events) = provider_events.get_events_mut_if_exist(id) {
+                    for event in events {
+                        process_event(event);
+                    }
                 }
+
+                for event in provider_events.wide_events_mut() {
+                    process_event(event);
+                }
+
+                /* Clear ancillary data */
+                ancillary.borrow_mut().event = None;
             }
         }));
 

--- a/one_collect/src/event/mod.rs
+++ b/one_collect/src/event/mod.rs
@@ -1615,6 +1615,7 @@ impl EventFormat {
 const EVENT_FLAG_NO_CALLSTACK:u64 = 1u64 << 0;
 const EVENT_FLAG_PROXY:u64 = 1u64 << 1;
 const EVENT_FLAG_NO_CPU_MASK:u64 = 1u64 << 2;
+const EVENT_FLAG_ID_WILD_CARD:u64 = 1u64 << 3;
 
 struct FieldSkip {
     loc_type: LocationType,
@@ -1724,6 +1725,17 @@ impl Event {
     /// Checks if the no_callstack flag is set for the event.
     pub fn has_no_callstack_flag(&self) -> bool {
         self.flags & EVENT_FLAG_NO_CALLSTACK != 0
+    }
+
+    /// Sets the id wild card flag for the event. Use this when the event should run
+    /// for any ID within it's scope. Scope is OS dependent.
+    pub fn set_id_wild_card_flag(&mut self) {
+        self.flags |= EVENT_FLAG_ID_WILD_CARD;
+    }
+
+    /// Checks if the id wild card flag is set for the event.
+    pub fn has_id_wild_card_flag(&self) -> bool {
+        self.flags & EVENT_FLAG_ID_WILD_CARD != 0
     }
 
     /// Sets the no_cpu_mask flag for the event. Use this when events are expected

--- a/one_collect/src/helpers/dotnet/os/windows.rs
+++ b/one_collect/src/helpers/dotnet/os/windows.rs
@@ -12,7 +12,9 @@ use crate::helpers::dotnet::universal::UniversalDotNetHelperOSHooks;
 #[cfg(feature = "scripting")]
 use crate::helpers::exporting::UniversalExporter;
 
+use crate::helpers::exporting::record::*;
 use crate::helpers::exporting::symbols::*;
+use crate::helpers::exporting::process::*;
 
 use crate::ReadOnly;
 use crate::event::*;
@@ -40,6 +42,11 @@ impl OSDotNetHelper {
     }
 }
 
+struct ProviderRecordEvent {
+    event: Event,
+    flags: DotNetProviderFlags,
+}
+
 pub trait DotNetHelperWindowsExt {
     fn with_jit_symbols(self) -> Self;
 }
@@ -54,6 +61,7 @@ impl DotNetHelperWindowsExt for DotNetHelper {
 
 pub(crate) struct OSDotNetEventFactory {
     filter_args: Writable<Option<HashMap<Guid, String>>>,
+    record_events: Writable<Option<Vec<ProviderRecordEvent>>>,
 }
 
 impl OSDotNetEventFactory {
@@ -62,6 +70,7 @@ impl OSDotNetEventFactory {
     pub fn new(_proxy: impl FnMut(String, usize) -> Option<Event> + 'static) -> Self {
         Self {
             filter_args: Writable::new(Some(HashMap::new())),
+            record_events: Writable::new(Some(Vec::new())),
         }
     }
 
@@ -156,8 +165,88 @@ impl OSDotNetEventFactory {
         &mut self,
         exporter: UniversalExporter) -> UniversalExporter {
         let filter_args = self.filter_args.clone();
+        let record_events = self.record_events.clone();
+        let callstack_keywords = Writable::new(Vec::new());
+        let fn_callstack_keywords = callstack_keywords.clone();
 
-        exporter.with_build_hook(move |mut session, _context| {
+        #[derive(Copy, Clone)]
+        struct DotNetRecordType {
+            kind: u16,
+            record_type: u16,
+        }
+
+        exporter
+        .with_settings_hook(move |mut settings| {
+            let mut record_events = record_events
+                .borrow_mut()
+                .take()
+                .unwrap_or_default();
+
+            for record_event in record_events.drain(..) {
+                let keyword = record_event.flags.callstack_keywords();
+
+                /* Add callstack keywords to list for session configuration */
+                if keyword != u64::MAX {
+                    fn_callstack_keywords.borrow_mut().push(
+                        (*record_event.event.extension().provider(),
+                        keyword));
+                }
+
+                let full_name = record_event.event.name().to_owned();
+                let mut static_formats = HashMap::new();
+
+                /* Add event for recording */
+                settings = settings.with_event(
+                    record_event.event,
+                    |_built| {
+                        Ok(())
+                    },
+                    move |trace| {
+                        let event_id = trace.id()?.unwrap_or(0);
+                        let attributes = trace.default_attributes()?;
+
+                        /* TODO: TraceLogging / Dynamic Formats */
+
+                        /* Static Format Lookup */
+                        let record_type = match static_formats.entry(event_id) {
+                            Occupied(entry) => { *entry.get() },
+                            Vacant(entry) => {
+                                let format = EventFormat::default();
+                                let kind = trace.kind(&full_name);
+
+                                let mut record_type = ExportRecordType::new(
+                                    kind,
+                                    event_id,
+                                    full_name.clone(),
+                                    format);
+
+                                record_type.set_original_data_flag();
+
+                                let record_type = trace.record_type(record_type);
+
+                                let record_type = DotNetRecordType {
+                                    kind,
+                                    record_type,
+                                };
+
+                                *entry.insert(record_type)
+                            }
+                        };
+
+                        /* Record */
+                        trace
+                            .sample_builder()
+                            .with_kind(record_type.kind)
+                            .with_record_type(record_type.record_type)
+                            .with_attributes(attributes)
+                            .with_record_all_event_data()
+                            .save_value(MetricValue::Count(1))
+                    });
+            }
+
+            Ok(settings)
+        })
+        .with_build_hook(move |mut session, _context| {
             let filter_args = filter_args
                 .borrow_mut()
                 .take()
@@ -197,18 +286,45 @@ impl OSDotNetEventFactory {
                 });
             }
 
+            for (provider, callstack_kw) in callstack_keywords.borrow_mut().drain(..) {
+                session.enable_provider(provider).ensure_callstack_keyword(callstack_kw);
+            }
+
             Ok(session)
         })
     }
 
     pub fn record_provider(
         &mut self,
-        _provider_name: &str,
-        _keyword: u64,
-        _level: u8,
-        _flags: DotNetProviderFlags) -> anyhow::Result<()> {
-        /* TODO: Utilize ETW provider level callback */
-        anyhow::bail!("Not yet supported.");
+        provider_name: &str,
+        keyword: u64,
+        level: u8,
+        flags: DotNetProviderFlags) -> anyhow::Result<()> {
+        let provider = guid_from_provider(provider_name)?;
+        let name = event_full_name(provider_name, provider, "Record");
+
+        let mut event = Event::new(0, name);
+        event.set_id_wild_card_flag();
+
+        *event.extension_mut().provider_mut() = provider;
+        *event.extension_mut().level_mut() = level;
+        *event.extension_mut().keyword_mut() = keyword;
+
+        match self.record_events.borrow_mut().as_mut() {
+            Some(record_events) => {
+                record_events.push(
+                    ProviderRecordEvent {
+                        event,
+                        flags,
+                    });
+            },
+            None => {
+                warn!("Record events no longer available for provider: provider={}", provider_name);
+                anyhow::bail!("Record events are no longer available.");
+            },
+        }
+
+        Ok(())
     }
 
     pub fn set_filter_args(

--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -140,6 +140,7 @@ struct ExportSampler {
     os: OSExportSampler,
     disable_callstacks: bool,
     version_override: Option<u16>,
+    id_override: Option<usize>,
     op_code_override: Option<u16>,
     span_id_override: Option<[u8; 8]>,
     trace_id_override: Option<[u8; 16]>,
@@ -171,6 +172,10 @@ pub trait ExportSamplerOSHooks {
     fn os_event_version(
         &self,
         data: &EventData) -> anyhow::Result<Option<u16>>;
+
+    fn os_event_id(
+        &self,
+        data: &EventData) -> anyhow::Result<Option<usize>>;
 
     fn os_event_op_code(
         &self,
@@ -205,6 +210,7 @@ impl ExportSampler {
             os,
             frames: Vec::new(),
             version_override: None,
+            id_override: None,
             op_code_override: None,
             span_id_override: None,
             trace_id_override: None,
@@ -218,6 +224,13 @@ impl ExportSampler {
         &mut self,
         version: Option<u16>) {
         self.version_override = version;
+    }
+
+    #[allow(dead_code)]
+    fn override_id(
+        &mut self,
+        id: Option<usize>) {
+        self.id_override = id;
     }
 
     fn override_op_code(
@@ -256,6 +269,15 @@ impl ExportSampler {
         match self.version_override {
             Some(version) => Ok(Some(version)),
             None => self.os_event_version(data),
+        }
+    }
+
+    fn id(
+        &self,
+        data: &EventData) -> anyhow::Result<Option<usize>> {
+        match self.id_override {
+            Some(id) => Ok(Some(id)),
+            None => self.os_event_id(data),
         }
     }
 
@@ -675,6 +697,10 @@ impl<'a> ExportTraceContext<'a> {
 
     pub fn tid(&self) -> anyhow::Result<u32> {
         self.sampler.borrow().os_event_tid(self.data)
+    }
+
+    pub fn id(&self) -> anyhow::Result<Option<usize>> {
+        self.sampler.borrow().id(self.data)
     }
 
     pub fn op_code(&self) -> anyhow::Result<Option<u16>> {

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -706,6 +706,12 @@ impl ExportSamplerOSHooks for ExportSampler {
         Ok(None)
     }
 
+    fn os_event_id(
+        &self,
+        _data: &EventData) -> anyhow::Result<Option<usize>> {
+        Ok(None)
+    }
+
     fn os_event_op_code(
         &self,
         _data: &EventData) -> anyhow::Result<Option<u16>> {

--- a/one_collect/src/helpers/exporting/os/windows.rs
+++ b/one_collect/src/helpers/exporting/os/windows.rs
@@ -143,6 +143,12 @@ impl ExportSamplerOSHooks for ExportSampler {
         Ok(Some(self.os.ancillary.borrow().version() as u16))
     }
 
+    fn os_event_id(
+        &self,
+        _data: &EventData) -> anyhow::Result<Option<usize>> {
+        Ok(Some(self.os.ancillary.borrow().id() as usize))
+    }
+
     fn os_event_op_code(
         &self,
         _data: &EventData) -> anyhow::Result<Option<u16>> {


### PR DESCRIPTION
On DotNet for Linux, we allow recording provider level events using a keyword and level filter. On Windows we just had a TODO item there. We need to be able to record all events within a given provider that meet the keyword and level constraints.

Add new wildcard ID flag to Event, this flags if an Event should represent all events within a scope. For Windows the scope is an ETW provider. On Linux, there is no scope currently, and the flag is ignored.

Add OS abstraction to get the actual event ID. This allows us to get the event ID from Windows ETW sources. On Linux, this is only available on a subset of events, so we return None since there is already a pattern for this.

Use new wildcard ID flag and create a provider wide event on Windows that records all events coming in. All events will currently be treated as non-self describing events and will have empty format details. For well known providers with documented formats this will work well. For self describing events, such as TraceLogging events, these won't work currently.

Use new os_event_id() abstactions to mark the actual event ID within the record payloads instead of the wildcard event (which has an ID of 0).

Add callstack keyword filtering to ETW, utilize this when provider wide recording is enabled and a keyword comes in with not all the bits set (at that point it's not a filter).

This addresses most of #187, however, self describing events are still missing, so keeping it open.