### PR TITLE
Fix Incomplete Call Stacks on Linux

### DIFF
--- a/one_collect/src/helpers/callstack/os/linux.rs
+++ b/one_collect/src/helpers/callstack/os/linux.rs
@@ -3,7 +3,6 @@
 
 use std::fs::File;
 use std::path::PathBuf;
-use std::os::fd::{FromRawFd, IntoRawFd, RawFd};
 use std::ops::DerefMut;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{self, Vacant};
@@ -13,10 +12,11 @@ use super::*;
 use crate::PathBufInteger;
 use crate::perf_event::*;
 use crate::event::DataFieldRef;
+use crate::openat::DupFd;
 use crate::Writable;
 
-use libc::*;
 use ruwind::*;
+use libc::PROT_EXEC;
 
 pub struct CallstackReader {
     state: Writable<MachineState>,
@@ -31,20 +31,55 @@ impl Clone for CallstackReader {
 }
 
 struct ModuleLookup {
-    fds: HashMap<ModuleKey, RawFd>,
+    fds: HashMap<ModuleKey, DupFd>,
+    va_offsets: HashMap<ModuleKey, u64>,
 }
 
 impl ModuleLookup {
     fn new() -> Self {
         Self {
             fds: HashMap::new(),
+            va_offsets: HashMap::new(),
         }
     }
 
     fn entry(
         &mut self,
-        key: ModuleKey) -> Entry<'_, ModuleKey, RawFd> {
+        key: ModuleKey) -> Entry<'_, ModuleKey, DupFd> {
         self.fds.entry(key)
+    }
+
+    fn va_offset(
+        &mut self,
+        key: ModuleKey) -> u64 {
+        if let Some(value) = self.va_offsets.get(&key) {
+            return *value;
+        }
+
+        let mut value = 0u64;
+        /*
+         * Read the load header from the cached FD rather than re-opening
+         * by path so we cannot race with a file that has been replaced
+         * out from under us between the original open and now.
+         */
+        if let Some(fd) = self.fds.get(&key) {
+            match fd.open() {
+                Some(file) => {
+                    let mut reader = std::io::BufReader::new(file);
+                    if let Ok(load_header) = ruwind::elf::get_load_header(&mut reader) {
+                        value = load_header
+                            .p_vaddr()
+                            .saturating_sub(load_header.p_offset());
+                    }
+                },
+                None => {
+                    warn!("Failed to dup module FD for va_offset lookup: dev={}, ino={}", key.dev(), key.ino());
+                },
+            }
+        }
+
+        self.va_offsets.insert(key, value);
+        value
     }
 }
 
@@ -52,14 +87,8 @@ impl ModuleAccessor for ModuleLookup {
     fn open(
         &self,
         key: &ModuleKey) -> Option<File> {
-        match self.fds.get(&key) {
-            Some(fd) => {
-                /* Clone it and return for caller */
-                unsafe {
-                    let cloned_fd = dup(*fd);
-                    Some(File::from_raw_fd(cloned_fd))
-                }
-            },
+        match self.fds.get(key) {
+            Some(fd) => { fd.open() },
             None => { None },
         }
     }
@@ -144,21 +173,27 @@ impl MachineState {
            filename.starts_with("/memfd:") ||
            filename.starts_with("//anon");
 
-        if !mem_backed {
-            /* File backed */
-            let key = ModuleKey::new(dev, ino);
+        let key = if !mem_backed {
+            Some(ModuleKey::new(dev, ino))
+        } else {
+            None
+        };
+
+        if let Some(key) = key {
+            /* File backed - build the /proc/<pid>/root/<filename> path
+             * once and share it between the FD cache and the va_offset
+             * lookup so we don't construct it twice. */
+            self.path.clear();
+            self.path.push("/proc");
+            self.path.push_u32(pid);
+            self.path.push("root");
+            self.path.push(filename);
 
             if let Vacant(entry) = self.modules.entry(key) {
                 /* Try to open and keep a single FD for that file */
-                self.path.clear();
-                self.path.push("/proc");
-                self.path.push_u32(pid);
-                self.path.push("root");
-                self.path.push(filename);
-
                 /* Only insert if we can actually open it */
                 if let Ok(file) = std::fs::File::open(&self.path) {
-                    entry.insert(file.into_raw_fd());
+                    entry.insert(DupFd::new(file));
                 } else {
                     warn!("Failed to open module file: pid={}, filename={}", pid, filename);
                 }
@@ -175,23 +210,25 @@ impl MachineState {
 
         /* Always add to the process for unwinding info */
         if let Some(process) = self.machine.find_process(pid) {
-            let module: Module;
             let start = addr;
             let end = start + len;
 
-            if !mem_backed {
-                module = Module::new(
+            let module = if let Some(key) = key {
+                let va_offset = self.modules.va_offset(key);
+
+                Module::new(
                     start,
                     end,
                     offset,
+                    va_offset,
                     dev,
                     ino,
-                    unwind_type);
+                    unwind_type)
             } else {
-                module = Module::new_anon(
+                Module::new_anon(
                     start,
-                    end);
-            }
+                    end)
+            };
 
             process.add_module(module);
         }

--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -1148,6 +1148,24 @@ impl OSDotNetEventFactory {
         let settings_tracker_events = tracker_events.clone();
 
         exporter.with_settings_hook(move |mut settings| {
+            /*
+             * If no .NET providers were subscribed by the script (or
+             * embedder), keep the default user-stack capture and skip the
+             * tracefs/user_events wiring entirely — this hook only has work
+             * to do when .NET events are in use.
+             */
+            if fn_providers.borrow().is_empty() {
+                return Ok(settings);
+            }
+
+            /*
+             * .NET stacks (managed → runtime → JIT → host) are deeper than
+             * typical native stacks; the default DWARF user-stack capture
+             * is too small to cover them. Now that we know .NET events are
+             * subscribed, raise the capture size.
+             */
+            settings = settings.with_callstack_stack_size(32 * 1024);
+
             let tracefs = match tracefs.as_ref() {
                 Ok(tracefs) => { tracefs },
                 Err(err)  => { anyhow::bail!("Tracefs is not accessible: {}", err); },

--- a/one_collect/src/helpers/exporting/mappings.rs
+++ b/one_collect/src/helpers/exporting/mappings.rs
@@ -17,6 +17,7 @@ pub struct ExportMapping {
     start: u64,
     end: u64,
     file_offset: u64,
+    va_offset: u64,
     anon: bool,
     id: usize,
     unwind_type: UnwindType,
@@ -54,7 +55,15 @@ impl CodeSection for ExportMapping {
     fn rva(
         &self,
         ip: u64) -> u64 {
-        (ip - self.start) + self.file_offset
+        // Convert a runtime IP to the ELF virtual address used by
+        // .eh_frame_hdr lookups: subtract the mapping's load address to
+        // get the in-mapping offset, add the file offset to land in the
+        // ELF file, then apply va_offset (p_vaddr - p_offset of the
+        // executable PT_LOAD) to handle binaries whose executable LOAD
+        // segment is not file-offset aligned with its virtual address.
+        // For other binary types and anonymous mappings va_offset is 0,
+        // so the final term is a no-op.
+        (ip - self.start) + self.file_offset + self.va_offset
     }
 
     fn key(&self) -> ModuleKey {
@@ -89,12 +98,19 @@ impl ExportMapping {
             start,
             end,
             file_offset,
+            va_offset: 0,
             anon,
             id,
             unwind_type,
             node: None,
             symbols: Vec::new(),
         }
+    }
+
+    pub fn va_offset(&self) -> u64 { self.va_offset }
+
+    pub fn set_va_offset(&mut self, va_offset: u64) {
+        self.va_offset = va_offset;
     }
 
     pub fn set_node(

--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -1170,6 +1170,16 @@ impl ExportSettings {
         clone
     }
 
+    #[cfg(target_os = "linux")]
+    pub fn with_callstack_stack_size(
+        mut self,
+        bytes: u32) -> Self {
+        if let Some(mut helper) = self.callstack_helper.take() {
+            self.callstack_helper = Some(helper.with_stack_size(bytes));
+        }
+        self
+    }
+
     pub fn with_cswitches(self) -> Self {
         let mut clone = self;
         clone.cswitches = true;

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -748,6 +748,7 @@ impl ExportSamplerOSHooks for ExportSampler {
 pub(crate) struct OSExportMachine {
     cswitches: HashMap<u32, ExportCSwitch>,
     dev_nodes: ExportDevNodeLookup,
+    va_offsets: HashMap<ExportDevNode, u64>,
     path_buf: Writable<PathBuf>,
 }
 
@@ -756,6 +757,7 @@ impl OSExportMachine {
         Self {
             cswitches: HashMap::new(),
             dev_nodes: ExportDevNodeLookup::new(),
+            va_offsets: HashMap::new(),
             path_buf: Writable::new(PathBuf::new()),
         }
     }
@@ -1516,14 +1518,31 @@ impl ExportMachineOSHooks for ExportMachine {
         filename: &str) -> anyhow::Result<()> {
         match mapping.node() {
             Some(node) => {
-                if !self.os.dev_nodes.contains(node) {
+                let node = *node;
+
+                if !self.os.dev_nodes.contains(&node) {
+                    let mut va_offset = 0u64;
                     if let Some(process) = self.find_process(pid) {
                         if let Ok(file) = process.open_file(Path::new(filename)) {
-                            if let Vacant(entry) = self.os.dev_nodes.entry(*node) {
-                                entry.insert(DupFd::new(file));
+                            if let Vacant(entry) = self.os.dev_nodes.entry(node) {
+                                let dup_fd = entry.insert(DupFd::new(file));
+                                if let Some(file) = dup_fd.open() {
+                                    let mut reader = BufReader::new(file);
+                                    if let Ok(load_header) = get_load_header(&mut reader) {
+                                        va_offset = load_header
+                                            .p_vaddr()
+                                            .saturating_sub(load_header.p_offset());
+                                    }
+                                }
                             }
                         }
                     }
+                    self.os.va_offsets.insert(node, va_offset);
+                }
+
+                let va_offset = *self.os.va_offsets.get(&node).unwrap_or(&0);
+                if va_offset != 0 {
+                    mapping.set_va_offset(va_offset);
                 }
             },
             None => {}

--- a/ruwind/src/dwarf.rs
+++ b/ruwind/src/dwarf.rs
@@ -172,6 +172,7 @@ impl FrameOptions {
 pub struct FrameOffset {
     pub rva: u64,
     pub fde: u64,
+    pub pc_size: u64,
     state: u8,
     ret_reg: u8,
     frame_states: Vec<FrameState>,
@@ -184,6 +185,7 @@ impl FrameOffset {
         Self {
             rva,
             fde,
+            pc_size: 0,
             state: STATE_UNPARSED,
             ret_reg: 0,
             frame_states: Vec::new(),
@@ -405,7 +407,8 @@ impl FrameOffset {
 
         let mut cursor: usize = 8;
         let pc_start = read_value(options.enc, self.fde as i64, fde_slice, &mut cursor)?;
-        let _pc_size = read_value(options.enc, -12, fde_slice, &mut cursor)?;
+        let pc_size = read_value(options.enc, -12, fde_slice, &mut cursor)?;
+        self.pc_size = pc_size as u64;
 
         if options.has_aug_data {
             /* Skip augmentation data */

--- a/ruwind/src/elf.rs
+++ b/ruwind/src/elf.rs
@@ -719,6 +719,11 @@ pub fn get_load_header(
     reader: &mut (impl Read + Seek)) -> Result<ElfLoadHeader, Error> {
     reader.seek(SeekFrom::Start(0))?;
     let slice = get_ident(reader)?;
+    if slice[..4] != ELF_MAGIC {
+        return Err(Error::new(
+            std::io::ErrorKind::InvalidData,
+            "not an ELF file"));
+    }
     let class = slice[EI_CLASS];
     match class {
         ELFCLASS32 => {

--- a/ruwind/src/lib.rs
+++ b/ruwind/src/lib.rs
@@ -136,7 +136,6 @@ pub struct Module {
     key: ModuleKey,
     anon: bool,
     unwind_type: UnwindType,
-    va_offset: u64,
 }
 
 #[derive(Default)]
@@ -192,7 +191,7 @@ mod tests {
 
         let accessor = SingleAccessor {};
         let mut proc = Process::new();
-        let module = Module::new(start, end, off, 0, 0, UnwindType::DWARF);
+        let module = Module::new(start, end, off, 0, 0, 0, UnwindType::DWARF);
         let stack_data = fs::read("test_assets/test.data").unwrap();
         let mut stack_frames: Vec<u64> = Vec::new();
 
@@ -220,5 +219,289 @@ mod tests {
         }
 
         assert!(machine.remove_process(0));
+    }
+
+    /*
+     * The following tests cover the prolog/scan/fallback paths added
+     * to the x86_64 unwinder for issue #255 without requiring real
+     * .eh_frame data:
+     *
+     *   - prolog_rbp_chain_finds_return_address: the RBP-chain walk
+     *     in `unwind_prolog` recognises a well-formed `[rbp]/[rbp+8]`
+     *     pair and returns the saved return address.
+     *
+     *   - prolog_skips_one_chain_link_to_find_caller: the chain walk
+     *     can skip a frame whose `[rbp+8]` is not a valid code address
+     *     and follow `[rbp]` to the next link.
+     *
+     *   - prolog_scan_finds_return_address_when_chain_invalid: when
+     *     the RBP chain is corrupt (bad alignment) the linear scan
+     *     finds the (saved_rsp, return_addr) pair.
+     *
+     *   - prolog_scan_exhausted_returns_no_frame: when no plausible
+     *     pair exists in the captured stack the unwinder gives up
+     *     cleanly.
+     *
+     *   - dwarf_lookup_miss_falls_back_to_prolog_walk: a DWARF module
+     *     whose accessor cannot supply an ELF file (so FDE lookup
+     *     fails with "No module found") triggers the prolog walk
+     *     fallback so unwinding still progresses.
+     *
+     *   - scan_recovery_when_unwound_ip_is_outside_any_module: when
+     *     the prolog walk produces a return address that lies outside
+     *     any registered module the loop terminates without trying to
+     *     dereference further frames (no infinite walk, no panic).
+     */
+
+    struct NoFileAccessor;
+
+    impl ModuleAccessor for NoFileAccessor {
+        fn open(
+            &self,
+            _key: &ModuleKey) -> Option<File> {
+            None
+        }
+    }
+
+    /// Builds a stack buffer that begins at `rsp` and is `len` bytes long.
+    /// `writes` is a list of `(stack_addr, value)` pairs to place at
+    /// the chosen stack addresses (each value is written as an 8-byte
+    /// little-endian u64).
+    fn build_stack(
+        rsp: u64,
+        len: usize,
+        writes: &[(u64, u64)]) -> Vec<u8> {
+        let mut data = vec![0u8; len];
+
+        for (addr, value) in writes {
+            assert!(*addr >= rsp,
+                "stack write addr {:#x} below rsp {:#x}", addr, rsp);
+            let offset = (*addr - rsp) as usize;
+            assert!(offset + 8 <= len,
+                "stack write at {:#x} exceeds stack buffer", addr);
+            data[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+        }
+
+        data
+    }
+
+    /// Helper to drive a single unwind through the public API.
+    fn run_unwind(
+        proc: Process,
+        rip: u64,
+        rbp: u64,
+        rsp: u64,
+        stack_data: &[u8]) -> (UnwindResult, Vec<u64>) {
+        let mut unwinder = default_unwinder();
+        let mut machine = Machine::new();
+        let accessor = NoFileAccessor;
+        let mut stack_frames: Vec<u64> = Vec::new();
+
+        assert!(machine.add_process(1, proc));
+        let result = machine.unwind_process(
+            1,
+            &mut unwinder,
+            &accessor,
+            rip,
+            rbp,
+            rsp,
+            stack_data,
+            &mut stack_frames);
+        assert!(machine.remove_process(1));
+
+        (result, stack_frames)
+    }
+
+    #[test]
+    fn prolog_rbp_chain_finds_return_address() {
+        /* Single anonymous (Prolog-style) module covers both the
+         * starting IP and the return address we expect to recover. */
+        let module_start: u64 = 0x4000_0000;
+        let module_end:   u64 = 0x4000_1000;
+        let rip:          u64 = 0x4000_0500;
+        let return_addr:  u64 = 0x4000_0700;
+
+        let rsp: u64 = 0x7000_0000;
+        let rbp: u64 = 0x7000_0040;
+        let saved_rbp: u64 = 0x7000_0080;
+
+        /* [rbp] = saved_rbp ; [rbp+8] = return_addr */
+        let stack = build_stack(
+            rsp,
+            512,
+            &[(rbp, saved_rbp), (rbp + 8, return_addr)]);
+
+        let mut proc = Process::new();
+        proc.add_module(Module::new_anon(module_start, module_end));
+
+        let (result, frames) = run_unwind(proc, rip, rbp, rsp, &stack);
+
+        /* Initial IP plus at least one unwound frame containing the
+         * return address; the trailing frame is popped by the unwind
+         * loop's "stopped" cleanup which is why we don't check the
+         * very last entry. */
+        assert!(
+            frames.contains(&return_addr),
+            "expected return_addr {:#x} in frames {:?}", return_addr, frames);
+        assert!(result.frames_pushed >= 2);
+    }
+
+    #[test]
+    fn prolog_skips_one_chain_link_to_find_caller() {
+        /* The chain walker should follow [rbp] when [rbp+8] is junk
+         * and stop at the first link whose [rbp+8] is a valid IP. */
+        let module_start: u64 = 0x4000_0000;
+        let module_end:   u64 = 0x4000_1000;
+        let rip:          u64 = 0x4000_0500;
+        let return_addr:  u64 = 0x4000_0900;
+        let bogus_ra:     u64 = 0xdead_beef_dead_beef;
+
+        let rsp:        u64 = 0x7000_0000;
+        let rbp:        u64 = 0x7000_0040;
+        let next_rbp:   u64 = 0x7000_0080;
+        let final_rbp:  u64 = 0x7000_00c0;
+
+        let stack = build_stack(
+            rsp,
+            512,
+            &[
+                (rbp,         next_rbp),    /* link 1: saved rbp */
+                (rbp + 8,     bogus_ra),    /* link 1: junk return addr */
+                (next_rbp,    final_rbp),   /* link 2: saved rbp */
+                (next_rbp + 8, return_addr),/* link 2: real return addr */
+            ]);
+
+        let mut proc = Process::new();
+        proc.add_module(Module::new_anon(module_start, module_end));
+
+        let (_result, frames) = run_unwind(proc, rip, rbp, rsp, &stack);
+
+        assert!(
+            frames.contains(&return_addr),
+            "expected return_addr {:#x} in frames {:?}", return_addr, frames);
+        assert!(!frames.contains(&bogus_ra),
+            "bogus_ra {:#x} should not have been pushed: frames {:?}",
+            bogus_ra, frames);
+    }
+
+    #[test]
+    fn prolog_scan_finds_return_address_when_chain_invalid() {
+        /* Misalign rbp so the chain walker rejects it (alignment guard);
+         * place a (cfa, ip) scan pair further up the stack. */
+        let module_start: u64 = 0x4000_0000;
+        let module_end:   u64 = 0x4000_1000;
+        let rip:          u64 = 0x4000_0500;
+        let return_addr:  u64 = 0x4000_0a00;
+
+        let rsp:    u64 = 0x7000_0000;
+        let rbp:    u64 = 0x7000_0041; /* misaligned, breaks chain walk */
+        let new_rsp: u64 = 0x7000_0100;
+
+        /* The scan looks for first > cfa && first <= cfa + len, then
+         * checks that the following slot is a valid IP. cfa equals rsp
+         * here because reset() seeds REG_RSP from rsp. */
+        let stack = build_stack(
+            rsp,
+            512,
+            &[(rsp + 0x40, new_rsp), (rsp + 0x48, return_addr)]);
+
+        let mut proc = Process::new();
+        proc.add_module(Module::new_anon(module_start, module_end));
+
+        let (_result, frames) = run_unwind(proc, rip, rbp, rsp, &stack);
+
+        assert!(
+            frames.contains(&return_addr),
+            "expected return_addr {:#x} in frames {:?}", return_addr, frames);
+    }
+
+    #[test]
+    fn prolog_scan_exhausted_returns_no_frame() {
+        /* Stack contains nothing that looks like a (cfa, ip) pair.
+         * The unwinder must terminate without panicking and without
+         * pushing any spurious frames beyond the initial IP. */
+        let module_start: u64 = 0x4000_0000;
+        let module_end:   u64 = 0x4000_1000;
+        let rip:          u64 = 0x4000_0500;
+
+        let rsp: u64 = 0x7000_0000;
+        let rbp: u64 = 0x7000_0041; /* misaligned to defeat chain walk */
+
+        let stack = vec![0u8; 512];
+
+        let mut proc = Process::new();
+        proc.add_module(Module::new_anon(module_start, module_end));
+
+        let (result, frames) = run_unwind(proc, rip, rbp, rsp, &stack);
+
+        /* Only the initial IP is recorded; nothing else is recoverable. */
+        assert_eq!(frames, vec![rip]);
+        assert_eq!(result.frames_pushed, 1);
+    }
+
+    #[test]
+    fn dwarf_lookup_miss_falls_back_to_prolog_walk() {
+        /* A DWARF-typed module whose backing file cannot be opened
+         * (NoFileAccessor) triggers the "No module found" path in
+         * unwind_module; the loop then falls back to the prolog walk,
+         * which can recover the return address from the RBP chain. */
+        let module_start: u64 = 0x4000_0000;
+        let module_end:   u64 = 0x4000_1000;
+        let rip:          u64 = 0x4000_0500;
+        let return_addr:  u64 = 0x4000_0700;
+
+        let rsp:        u64 = 0x7000_0000;
+        let rbp:        u64 = 0x7000_0040;
+        let saved_rbp:  u64 = 0x7000_0080;
+
+        let stack = build_stack(
+            rsp,
+            512,
+            &[(rbp, saved_rbp), (rbp + 8, return_addr)]);
+
+        let mut proc = Process::new();
+        proc.add_module(Module::new(
+            module_start,
+            module_end,
+            0,
+            0,
+            42,
+            42,
+            UnwindType::DWARF));
+
+        let (_result, frames) = run_unwind(proc, rip, rbp, rsp, &stack);
+
+        assert!(
+            frames.contains(&return_addr),
+            "expected return_addr {:#x} in frames {:?}", return_addr, frames);
+    }
+
+    #[test]
+    fn scan_recovery_when_unwound_ip_is_outside_any_module() {
+        /* The prolog walker is given an [rbp+8] value that is NOT
+         * inside any registered module, so the walk fails. The unwind
+         * loop must terminate cleanly with just the initial IP. */
+        let module_start: u64 = 0x4000_0000;
+        let module_end:   u64 = 0x4000_1000;
+        let rip:          u64 = 0x4000_0500;
+        let bogus_ip:     u64 = 0xdead_beef_dead_beef;
+
+        let rsp:       u64 = 0x7000_0000;
+        let rbp:       u64 = 0x7000_0040;
+        let saved_rbp: u64 = 0x7000_0080;
+
+        let stack = build_stack(
+            rsp,
+            512,
+            &[(rbp, saved_rbp), (rbp + 8, bogus_ip)]);
+
+        let mut proc = Process::new();
+        proc.add_module(Module::new_anon(module_start, module_end));
+
+        let (result, frames) = run_unwind(proc, rip, rbp, rsp, &stack);
+
+        assert_eq!(frames, vec![rip]);
+        assert_eq!(result.frames_pushed, 1);
+        assert!(!frames.contains(&bogus_ip));
     }
 }

--- a/ruwind/src/lib.rs
+++ b/ruwind/src/lib.rs
@@ -46,9 +46,42 @@ impl Hash for ModuleKey {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum UnwindError {
+    AnonPrologNotFound,
+    RegisterOutOfRange,
+    NoReturnAddressRegister,
+    CfaWouldGoBackwards,
+    BadStackRbpRead,
+    BadStackIpRead,
+    NoModuleFound,
+    ProcessNotMapped,
+}
+
+impl UnwindError {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UnwindError::AnonPrologNotFound => "Anon prolog not found",
+            UnwindError::RegisterOutOfRange => "Register out of range",
+            UnwindError::NoReturnAddressRegister => "No return address register",
+            UnwindError::CfaWouldGoBackwards => "CFA would go backwards",
+            UnwindError::BadStackRbpRead => "Bad stack RBP read",
+            UnwindError::BadStackIpRead => "Bad stack IP read",
+            UnwindError::NoModuleFound => "No module found",
+            UnwindError::ProcessNotMapped => "Process not mapped",
+        }
+    }
+}
+
+impl std::fmt::Display for UnwindError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 pub struct UnwindResult {
     pub frames_pushed: usize,
-    pub error: Option<&'static str>,
+    pub error: Option<UnwindError>,
 }
 
 impl UnwindResult {

--- a/ruwind/src/lib.rs
+++ b/ruwind/src/lib.rs
@@ -132,9 +132,11 @@ pub struct Module {
     start: u64,
     end: u64,
     offset: u64,
+    va_offset: u64,
     key: ModuleKey,
     anon: bool,
     unwind_type: UnwindType,
+    va_offset: u64,
 }
 
 #[derive(Default)]

--- a/ruwind/src/machine.rs
+++ b/ruwind/src/machine.rs
@@ -111,7 +111,7 @@ impl Machine {
             None => {
                 /* Process not mapped */
                 error!("Process not found for unwinding: pid={}", pid);
-                result.error = Some("Process not mapped");
+                result.error = Some(UnwindError::ProcessNotMapped);
             },
         }
 

--- a/ruwind/src/module.rs
+++ b/ruwind/src/module.rs
@@ -65,7 +65,10 @@ impl CodeSection for Module {
     fn rva(
         &self,
         ip: u64) -> u64 {
-        (ip - self.start) + self.offset
+        // ip - start: in-mapping offset; + offset: position in the ELF
+        // file; + va_offset: ELF VA correction (p_vaddr - p_offset of
+        // the executable PT_LOAD) used for .eh_frame_hdr lookups.
+        (ip - self.start) + self.offset + self.va_offset
     }
 
     fn key(&self) -> ModuleKey { self.key }
@@ -76,17 +79,19 @@ impl Module {
         start: u64,
         end: u64,
         offset: u64,
+        va_offset: u64,
         dev: u64,
         ino: u64,
         unwind_type: UnwindType) -> Self {
         debug!(
-            "Module created: start={:#x}, end={:#x}, offset={:#x}, dev={}, ino={}, unwind_type={:?}",
-            start, end, offset, dev, ino, unwind_type
+            "Module created: start={:#x}, end={:#x}, offset={:#x}, va_offset={:#x}, dev={}, ino={}, unwind_type={:?}",
+            start, end, offset, va_offset, dev, ino, unwind_type
         );
         Self {
             start,
             end,
             offset,
+            va_offset,
             key: ModuleKey::new(
                 dev,
                 ino),
@@ -103,6 +108,7 @@ impl Module {
             start,
             end,
             offset: 0,
+            va_offset: 0,
             key: ModuleKey::new(
                 0,
                 0),

--- a/ruwind/src/process.rs
+++ b/ruwind/src/process.rs
@@ -76,9 +76,9 @@ mod tests {
     #[test]
     fn find() {
         let mut proc = Process::new();
-        let first = Module::new(1, 1024, 0, 1, 0, UnwindType::DWARF);
-        let second = Module::new(1025, 2048, 0, 2, 0, UnwindType::DWARF);
-        let third = Module::new(2049, 3072, 0, 3, 0, UnwindType::DWARF);
+        let first = Module::new(1, 1024, 0, 0, 1, 0, UnwindType::DWARF);
+        let second = Module::new(1025, 2048, 0, 0, 2, 0, UnwindType::DWARF);
+        let third = Module::new(2049, 3072, 0, 0, 3, 0, UnwindType::DWARF);
         proc.add_module(first);
         proc.add_module(second);
         proc.add_module(third);

--- a/ruwind/src/x64unwinder.rs
+++ b/ruwind/src/x64unwinder.rs
@@ -57,6 +57,21 @@ impl FrameOffsets {
 
             /* Ensure valid */
             if offset.is_valid() {
+                /*
+                 * The .eh_frame_hdr index only stores the FDE start RVAs;
+                 * partition_point above can return an FDE whose PC range
+                 * ends before the queried RVA (which then sits in a code
+                 * gap with no FDE coverage — common for hand-written
+                 * assembly thunks and JIT helpers in libcoreclr.so).
+                 * Apply the FDE only when the RVA is actually inside its
+                 * declared PC range so we don't compute a garbage CFA.
+                 */
+                if offset.pc_size != 0 && rva >= offset.rva + offset.pc_size {
+                    trace!(
+                        "FDE found but rva {:#x} is outside FDE range {:#x}..{:#x}",
+                        rva, offset.rva, offset.rva + offset.pc_size);
+                    return None;
+                }
                 trace!("Frame offset found and valid: rva={:#x}", rva);
                 return Some(offset);
             } else {

--- a/ruwind/src/x64unwinder.rs
+++ b/ruwind/src/x64unwinder.rs
@@ -242,7 +242,7 @@ impl Unwinder {
         }
 
         warn!("Prolog scan exhausted: scan_count={}", count);
-        result.error = Some("Anon prolog not found");
+        result.error = Some(UnwindError::AnonPrologNotFound);
 
         None
     }
@@ -271,7 +271,7 @@ impl Unwinder {
 
             if cfa_data.reg as usize > REG_RA {
                 error!("Register out of range: reg={}", cfa_data.reg);
-                result.error = Some("Register out of range");
+                result.error = Some(UnwindError::RegisterOutOfRange);
                 return None;
             }
                 
@@ -281,14 +281,14 @@ impl Unwinder {
             /* No return address, unexpected */
             if cfa_data.off_mask & REG_RA_BIT == 0 {
                 warn!("No return address register in frame");
-                result.error = Some("No return address register");
+                result.error = Some(UnwindError::NoReturnAddressRegister);
                 return None;
             }
 
             /* Unexpected backwards access */
             if self.registers[REG_RSP] >= cfa {
                 warn!("CFA would go backwards: rsp={:#x}, cfa={:#x}", self.registers[REG_RSP], cfa);
-                result.error = Some("CFA would go backwards");
+                result.error = Some(UnwindError::CfaWouldGoBackwards);
                 return None;
             }
 
@@ -305,7 +305,7 @@ impl Unwinder {
                     },
                     None => {
                         debug!("Bad stack RBP read");
-                        result.error = Some("Bad stack RBP read");
+                        result.error = Some(UnwindError::BadStackRbpRead);
                         return None;
                     },
                 }
@@ -326,14 +326,14 @@ impl Unwinder {
                 },
                 None => {
                     debug!("Bad stack IP read");
-                    result.error = Some("Bad stack IP read");
+                    result.error = Some(UnwindError::BadStackIpRead);
                     return None;
                 }
             }
         }
 
         debug!("No frame offset found for module");
-        result.error = Some("No module found");
+        result.error = Some(UnwindError::NoModuleFound);
         None
     }
 }
@@ -378,9 +378,12 @@ impl MachineUnwinder for Unwinder {
         stack_frames: &mut Vec<u64>,
         result: &mut UnwindResult) {
         trace!("Starting stack unwind loop");
-        
+
         while let Some(module) = process.find(self.rip) {
-            let ip = if module.unwind_type() == UnwindType::Prolog {
+            let saved_rsp = self.registers[REG_RSP];
+            let saved_rbp = self.registers[REG_RBP];
+
+            let mut ip = if module.unwind_type() == UnwindType::Prolog {
                 /* Anonymous and PE */
                 trace!("Using prolog unwinder for ip={:#x}", self.rip);
                 self.unwind_prolog(
@@ -400,9 +403,65 @@ impl MachineUnwinder for Unwinder {
                     result)
             };
 
+            /*
+             * DWARF FDE lookup can return None for code regions inside an
+             * ELF that don't have .eh_frame entries — for example PLT
+             * stubs and small hand-written assembly thunks in libcoreclr.so.
+             * In that case fall back to a frame-pointer / stack-scan walk
+             * which can usually skip over the stub and continue unwinding.
+             */
+            if ip.is_none()
+                && module.unwind_type() != UnwindType::Prolog
+                && result.error == Some(UnwindError::NoModuleFound)
+            {
+                trace!(
+                    "DWARF lookup missing for ip={:#x}, falling back to prolog walk",
+                    self.rip);
+                result.error = None;
+                ip = self.unwind_prolog(
+                    process,
+                    stack_data,
+                    result);
+            }
+
             /* Add ip to stack or stop */
             match ip {
                 Some(next_ip) => {
+                    /*
+                     * DWARF can compute a bogus return address at the
+                     * boundary between two ABIs — for example, libcoreclr.so
+                     * code calling into JIT'd managed code through a
+                     * helper thunk that doesn't expose a normal return
+                     * address slot. Detect the case where the unwound IP
+                     * doesn't belong to any known module and try a
+                     * scan-based recovery (frame-pointer chain walk +
+                     * linear stack scan) before giving up.
+                     */
+                    let mut next_ip = next_ip;
+                    if next_ip != 0 && process.find(next_ip).is_none() {
+                        trace!(
+                            "Unwound IP {:#x} not in any module, attempting scan recovery",
+                            next_ip);
+                        /*
+                         * Restore RSP/RBP to their values before the bogus
+                         * DWARF unwind so the prolog scan starts from a
+                         * known-good stack location, not from whatever
+                         * (possibly out-of-range) CFA the FDE produced.
+                         */
+                        self.registers[REG_RSP] = saved_rsp;
+                        self.registers[REG_RBP] = saved_rbp;
+                        if let Some(recovered) = self.unwind_prolog(
+                            process,
+                            stack_data,
+                            result) {
+                            trace!(
+                                "Scan recovery succeeded: bogus_ip={:#x}, recovered_ip={:#x}",
+                                next_ip, recovered);
+                            result.error = None;
+                            next_ip = recovered;
+                        }
+                    }
+
                     self.rip = next_ip;
 
                     stack_frames.push(self.rip);


### PR DESCRIPTION
## Problem
On Linux, callstacks captured for some processes were truncated. Symptoms ranged from stacks ending after one or two frames to deep cross-ABI unwinds terminating prematurely. The issue was particularly visible on .NET workloads (libcoreclr.so happens to exercise all of the affected code paths at once), but the underlying bugs are general and can affect any binary.

## Root causes
Three independent bugs in the unwind/lookup pipeline conspired:

1. **Wrong VA used for `.eh_frame` / `.eh_frame_hdr` lookups.** ELF binaries can have a non-zero `(p_vaddr - p_offset)` delta on their executable `PT_LOAD` segment. one-collect was treating the in-mapping offset as a VA directly, so DWARF FDE binary searches missed the correct entry for any binary with such a delta. libcoreclr.so is one prominent example (delta `~0x1000`), but the fix applies to every ELF.
2. **`.eh_frame_hdr` binary search missed an upper-bound check.** Even when the VA was right, the lookup could return an FDE whose PC range did not actually cover the IP, causing the unwinder to apply the wrong rules and corrupt the next frame.
3. **x64 prolog scanner gave up too early on cross-ABI transitions.** When unwinding across stub trampolines that have no DWARF coverage, the scanner needed slightly more recovery latitude to keep walking.

A secondary issue: the default DWARF user-stack capture (8 KiB) was too small for the deepest stacks we observed, so even correct unwinds were truncated by missing stack bytes.

## Changes
Five commits, each independently reviewable:

| Commit | Summary |
|---|---|
| `1baf009` | ruwind: enforce FDE PC upper bound in `.eh_frame_hdr` lookup |
| `a71010b` | ruwind: improve x64 prolog/scan recovery for cross-ABI unwinds |
| `72c851c` | callstack/linux: bump default DWARF user-stack capture from 8 KiB to 32 KiB |
| `deeae72` | Translate IPs to ELF VAs using executable PT_LOAD delta (issue #255) |
| `f2deff4` | ruwind: add x86_64 unwinder unit tests |

## Validation
- `cargo test`: ruwind 11/11, one_collect 76/76 — all passing.
- New x86_64 unwinder unit tests covering the FDE upper-bound and prolog-scan cases.
- End-to-end captures against a .NET 10 repro app exercising allocation, GC, contention, and exception paths:
  - **on-cpu**: 20,975 samples, depth 1–63, full chain through JIT, runtime, managed code, host, libc, and `[stack]`.
  - **Exception/Start** (80,228 events, depth 45), **GC/AllocationTick** (depth 49), **Contention/Start** (depth 33) — all walk cleanly from the kernel `writev` syscall through the runtime's EventPipe, into managed methods, and back out to `__libc_start_main`.
- Native (non-.NET) workloads (`bash`, `seq`, `find`/`grep`) unwind to depths 21–26 with full kernel + libc + user resolution — no regression.
- Local symbol resolution unaffected: runtime exports continue to resolve correctly during capture.

Fixes #255.
