### PR TITLE
Handle wraparound in ring buffer peek

### DIFF
--- a/one_collect/src/perf_event/rb/mod.rs
+++ b/one_collect/src/perf_event/rb/mod.rs
@@ -647,7 +647,20 @@ impl<'a> CpuRingReader {
         let end = start + 8;
 
         let data_slice = self.data_slice();
-        u64::from_ne_bytes(data_slice[start..end].try_into().unwrap())
+
+        if end <= self.data_size as usize {
+            u64::from_ne_bytes(data_slice[start..end].try_into().unwrap())
+        } else {
+            // Data wrapped, so copy to a buffer before parsing.
+            let mut bytes = [0u8; 8];
+
+            let first_part = self.data_size as usize - start;
+            bytes[..first_part].copy_from_slice(&data_slice[start..]);
+            let remaining = 8 - first_part;
+            bytes[first_part..].copy_from_slice(&data_slice[..remaining]);
+
+            u64::from_ne_bytes(bytes)
+        }
     }
 
     pub fn read(
@@ -1790,6 +1803,36 @@ mod tests {
         assert_eq!(1, u64::from_ne_bytes(read[8..16].try_into().unwrap()));
 
         assert!(!cursor.more());
+        reader.end_reading(&cursor);
+    }
+
+    #[test]
+    fn peek_u64_wraps_around() {
+        let data_size: usize = 4096;
+        let data_offset: usize = 4096;
+        let mut data = vec![0u8; data_offset + data_size];
+        let slice = data.as_mut_slice();
+
+        slice[1040..1048].copy_from_slice(&(data_offset as u64).to_ne_bytes());
+        slice[1048..1056].copy_from_slice(&(data_size as u64).to_ne_bytes());
+
+        // Place a u64 straddling the boundary: 3 bytes at end, 5 at start
+        let expected: u64 = 42;
+        let bytes = expected.to_ne_bytes();
+        slice[data_offset + data_size - 3..data_offset + data_size].copy_from_slice(&bytes[..3]);
+        slice[data_offset..data_offset + 5].copy_from_slice(&bytes[3..]);
+
+        // Tail at data_size - 3, head at tail + 8
+        let tail: u64 = (data_size as u64) - 3;
+        slice[1024..1032].copy_from_slice(&(tail + 8).to_ne_bytes());
+        slice[1032..1040].copy_from_slice(&tail.to_ne_bytes());
+
+        let mut reader = CpuRingReader::new_unowned(data.as_mut_ptr(), data.len());
+        let mut cursor = CpuRingCursor::default();
+        reader.begin_reading(&mut cursor);
+
+        assert_eq!(expected, reader.peek_u64(&cursor, 0));
+
         reader.end_reading(&cursor);
     }
 }


### PR DESCRIPTION
I got the below panic on Linux. It'd happen within a few seconds after starting `record-trace`. It was intermittent.

```
root [ /src ]# RUST_BACKTRACE=full ./record-trace --on-cpu
Recording started.  Press CTRL+C to stop.

thread 'main' (2437410) panicked at /home/zach/git/one-collect/one_collect/src/perf_event/rb/mod.rs:628:39:
range end index 1048579 out of range for slice of length 1048576
stack backtrace:
   0:     0x7015bf4cad7a - <<std[b3a72215023e19aa]::sys::backtrace::BacktraceLock>::print::DisplayBacktrace as core[2c0e279f4be3ce47]::fmt::Display>::fmt
   1:     0x7015bf4fd31a - core[2c0e279f4be3ce47]::fmt::write
   2:     0x7015bf4d0e12 - <std[b3a72215023e19aa]::sys::stdio::unix::Stderr as std[b3a72215023e19aa]::io::Write>::write_fmt
   3:     0x7015bf4b4294 - std[b3a72215023e19aa]::panicking::default_hook::{closure#0}
   4:     0x7015bf4c5e2c - std[b3a72215023e19aa]::panicking::default_hook
   5:     0x7015bf4c5feb - std[b3a72215023e19aa]::panicking::panic_with_hook
   6:     0x7015bf4b4348 - std[b3a72215023e19aa]::panicking::panic_handler::{closure#0}
   7:     0x7015bf4a93d9 - std[b3a72215023e19aa]::sys::backtrace::__rust_end_short_backtrace::<std[b3a72215023e19aa]::panicking::panic_handler::{closure#0}, !>
   8:     0x7015bf4b4c4d - __rustc[c8a7c5c4b6a2cdce]::rust_begin_unwind
   9:     0x7015bf0461dc - core[2c0e279f4be3ce47]::panicking::panic_fmt
  10:     0x7015bf0462a8 - core[2c0e279f4be3ce47]::slice::index::slice_index_fail
  11:     0x7015bf1c3e84 - <one_collect[c8bb49c335157244]::perf_event::rb::source::RingBufDataSource>::read_time
  12:     0x7015bf1c6b96 - <one_collect[c8bb49c335157244]::perf_event::rb::source::RingBufDataSource as one_collect[c8bb49c335157244]::perf_event::PerfDataSource>::read
  13:     0x7015bf1e22b8 - <one_collect[c8bb49c335157244]::perf_event::PerfSession>::parse_perf_data
  14:     0x7015bf05e945 - <one_collect[c8bb49c335157244]::helpers::exporting::universal::UniversalExporter>::parse_until::<<engine[e2b1210dd1b887a5]::recorder::Recorder>::run::{closure#1}>
  15:     0x7015bf050837 - <engine[e2b1210dd1b887a5]::recorder::Recorder>::run
  16:     0x7015bf046f79 - record_trace[2ddca4dacbd28023]::main
  17:     0x7015bf046ab3 - std[b3a72215023e19aa]::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>
  18:     0x7015bf04ad79 - std[b3a72215023e19aa]::rt::lang_start::<()>::{closure#0}
  19:     0x7015bf4c4dbf - std[b3a72215023e19aa]::rt::lang_start_internal
  20:     0x7015bf047655 - main
Segmentation fault (core dumped)
```

Ignoring the segfault during the backtrace, I'm pretty sure the panic comes from `peek_u64`, which is called by `read_time`. It indexes the ring buffer data and doesn't handle wraparound.

This PR updates `peek_u64` to match what `read` does.

Aside, I see that `peek_header` doesn't handle wraparound either. ~~That should be fine though, assuming headers are always 8-byte aligned.~~