### PR TITLE
Use types from windows-sys

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -757,3 +757,35 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
+
+windows-sys
+===========
+
+MIT License
+
+Copyright (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/one_collect/Cargo.lock
+++ b/one_collect/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
  "sha1",
  "tracing",
  "twox-hash",
+ "windows-sys",
  "winreg",
 ]
 

--- a/one_collect/Cargo.toml
+++ b/one_collect/Cargo.toml
@@ -24,6 +24,18 @@ tracing = "0.1"
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.55.0"
 
+# windows-sys version tracks what winreg resolves to (currently 0.59); bump in
+# lockstep.
+#
+# Cargo unifies features additively across the dep graph, so the actual
+# windows-sys compilation also includes the features winreg enables (e.g.
+# Win32_System_Registry). We deliberately list only the features `etw/`
+# uses directly, so this manifest documents our own surface rather than
+# transitively inherited features.
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.59"
+features = ["Win32_System_Diagnostics_Etw"]
+
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.153"
 

--- a/one_collect/Cargo.toml
+++ b/one_collect/Cargo.toml
@@ -24,15 +24,24 @@ tracing = "0.1"
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.55.0"
 
-# windows-sys version tracks what winreg resolves to (currently 0.59); bump in
-# lockstep.
+# windows-sys is intentionally NOT gated to `cfg(target_os = "windows")`.
+# The `etw` module is gated by `cfg(any(doc, target_os = "windows"))` in
+# lib.rs, so rustdoc (which sets `cfg(doc)`) compiles it on every target
+# including Linux; the `pub use windows_sys::…` re-exports in `etw/abi.rs`
+# need the crate to be resolvable there too. On non-Windows targets
+# windows-sys compiles to a no-op at lib build time (type definitions only;
+# link directives don't fire until an executable is built), and because
+# nothing in the Linux code paths references windows-sys symbols the
+# linker drops it entirely — no impact on the Linux binary size.
+#
+# Version tracks what winreg resolves to (currently 0.59); bump in lockstep.
 #
 # Cargo unifies features additively across the dep graph, so the actual
 # windows-sys compilation also includes the features winreg enables (e.g.
 # Win32_System_Registry). We deliberately list only the features `etw/`
 # uses directly, so this manifest documents our own surface rather than
 # transitively inherited features.
-[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+[dependencies.windows-sys]
 version = "0.59"
 features = ["Win32_System_Diagnostics_Etw"]
 

--- a/one_collect/src/etw/abi.rs
+++ b/one_collect/src/etw/abi.rs
@@ -463,65 +463,95 @@ impl Default for ENABLE_TRACE_PARAMETERS {
     }
 }
 
-#[repr(C)]
-#[allow(non_snake_case)]
-pub struct EVENT_DESCRIPTOR {
-    pub Id: u16,
-    pub Version: u8,
-    pub Channel: u8,
-    pub Level: u8,
-    pub Opcode: u8,
-    pub Task: u16,
-    pub Keyword: u64,
+// The four ETW types that surface on the crate's public API
+// (`AncillaryData::record()` returns a `&EVENT_RECORD`, and the upcoming
+// `TdhDecoder` will take one) come from `windows-sys` so consumers and the
+// decoder share a single type identity. The rest of this file's ETW
+// surface (`EVENT_TRACE_PROPERTIES`, `WNODE_HEADER`, `ENABLE_TRACE_PARAMETERS`,
+// the extern entry points, etc.) is internal-only and stays hand-rolled
+// to keep the migration localized.
+pub use windows_sys::Win32::System::Diagnostics::Etw::{
+    EVENT_HEADER_EXTENDED_DATA_ITEM,
+    EVENT_RECORD,
+};
+
+/// Extension trait providing the few ergonomic accessors the rest of the
+/// `etw` module needs on `EVENT_RECORD`. `EVENT_RECORD` is a foreign type
+/// now, so inherent methods aren't allowed; importing `EventRecordExt`
+/// preserves call-site syntax like `record.user_data_slice()`. Crate-
+/// internal only — external consumers receive `&EVENT_RECORD` and hand it
+/// to the decoder, they never need these accessors themselves.
+pub(crate) trait EventRecordExt {
+    fn user_data_slice(&self) -> &[u8];
+    fn processor_index(&self) -> u16;
+    fn provider_guid(&self) -> Guid;
+    fn activity_guid(&self) -> Guid;
 }
 
-#[repr(C)]
-#[allow(non_snake_case)]
-pub struct EVENT_HEADER {
-    pub Size: u16,
-    pub HeaderType: u16,
-    pub Flags: u16,
-    pub EventProperty: u16,
-    pub ThreadId: u32,
-    pub ProcessId: u32,
-    pub TimeStamp: u64,
-    pub ProviderId: Guid,
-    pub EventDescriptor: EVENT_DESCRIPTOR,
-    pub KernelTime: u32,
-    pub UserTime: u32,
-    pub ActivityId: Guid,
-}
+// SAFETY guard for the `provider_guid` / `activity_guid` transmutes below.
+// `mem::transmute` already enforces same size at compile time, but spelling
+// the assumption out gives a clear error message if a future `windows-sys`
+// bump ever changes the `GUID` layout.
+const _: () = assert!(
+    std::mem::size_of::<Guid>() == std::mem::size_of::<windows_sys::core::GUID>(),
+    "Guid and windows_sys::core::GUID must have identical size",
+);
+const _: () = assert!(
+    std::mem::align_of::<Guid>() == std::mem::align_of::<windows_sys::core::GUID>(),
+    "Guid and windows_sys::core::GUID must have identical alignment",
+);
 
-#[repr(C)]
-#[allow(non_snake_case)]
-pub struct EVENT_HEADER_EXTENDED_DATA_ITEM {
-    pub Reserved1: u16,
-    pub ExtType: u16,
-    pub Linkage: u16,
-    pub DataSize: u16,
-    pub DataPtr: *const u8,
-}
+// SAFETY guard for the `processor_index` union read below. The
+// `BufferContext.Anonymous` union has two arms (`ProcessorIndex: u16` and
+// a packed `{ProcessorNumber: u8, Alignment: u8}`) that both occupy the
+// same two bytes. If `windows-sys` ever grows the union to a third, larger
+// variant or marks it `#[repr(packed)]`, our `u16` read would silently
+// miss bytes or become unaligned; catch either at build time instead.
+const _: () = assert!(
+    std::mem::size_of::<
+        windows_sys::Win32::System::Diagnostics::Etw::ETW_BUFFER_CONTEXT_0
+    >() == 2,
+    "ETW_BUFFER_CONTEXT_0 union must remain 2 bytes",
+);
+const _: () = assert!(
+    std::mem::align_of::<
+        windows_sys::Win32::System::Diagnostics::Etw::ETW_BUFFER_CONTEXT_0
+    >() >= std::mem::align_of::<u16>(),
+    "ETW_BUFFER_CONTEXT_0 union must be at least u16-aligned",
+);
 
-#[repr(C)]
-#[allow(non_snake_case)]
-pub struct EVENT_RECORD {
-    pub EventHeader: EVENT_HEADER,
-    pub ProcessorIndex: u16,
-    pub LoggerId: u16,
-    pub ExtendedDataCount: u16,
-    pub UserDataLength: u16,
-    pub ExtendedData: *const EVENT_HEADER_EXTENDED_DATA_ITEM,
-    pub UserData: *const u8,
-    pub UserContext: *const std::ffi::c_void,
-}
-
-impl EVENT_RECORD {
-    pub fn user_data_slice(&self) -> &[u8] {
+impl EventRecordExt for EVENT_RECORD {
+    #[inline]
+    fn user_data_slice(&self) -> &[u8] {
         unsafe {
             std::slice::from_raw_parts(
-                self.UserData,
+                self.UserData as *const u8,
                 self.UserDataLength as usize)
         }
+    }
+
+    #[inline]
+    fn processor_index(&self) -> u16 {
+        // SAFETY: `BufferContext.Anonymous` is a union whose two arms
+        // (`ProcessorIndex: u16` and `{ProcessorNumber: u8, Alignment: u8}`)
+        // alias the same two bytes; either arm always contains a valid
+        // bit-pattern for a `u16`. The const assertion above guards the
+        // 2-byte size against future `windows-sys` layout drift.
+        unsafe { self.BufferContext.Anonymous.ProcessorIndex }
+    }
+
+    #[inline]
+    fn provider_guid(&self) -> Guid {
+        // SAFETY: `Guid` and `windows_sys::core::GUID` are both `#[repr(C)]`
+        // with identical field order, widths, and (asserted above) size and
+        // alignment, so a bit-for-bit transmute is sound.
+        unsafe { std::mem::transmute(self.EventHeader.ProviderId) }
+    }
+
+    #[inline]
+    fn activity_guid(&self) -> Guid {
+        // SAFETY: see `provider_guid` above.
+        unsafe { std::mem::transmute(self.EventHeader.ActivityId) }
     }
 }
 

--- a/one_collect/src/etw/mod.rs
+++ b/one_collect/src/etw/mod.rs
@@ -22,6 +22,7 @@ use abi::{
     EVENT_RECORD,
     EVENT_HEADER_EXTENDED_DATA_ITEM,
     CLASSIC_EVENT_ID,
+    EventRecordExt,
 };
 
 pub const PROPERTY_ENABLE_KEYWORD_0: u32 = abi::EVENT_ENABLE_PROPERTY_ENABLE_KEYWORD_0;
@@ -58,7 +59,7 @@ impl AncillaryData {
     pub fn cpu(&self) -> u32 {
         match self.event {
             Some(event) => {
-                unsafe { (*event).ProcessorIndex as u32 }
+                unsafe { (*event).processor_index() as u32 }
             },
             None => { 0 },
         }
@@ -85,7 +86,7 @@ impl AncillaryData {
     pub fn time(&self) -> u64 {
         match self.event {
             Some(event) => {
-                unsafe { (*event).EventHeader.TimeStamp }
+                unsafe { (*event).EventHeader.TimeStamp as u64 }
             },
             None => { 0 },
         }
@@ -94,7 +95,7 @@ impl AncillaryData {
     pub fn provider(&self) -> Guid {
         match self.event {
             Some(event) => {
-                unsafe { (*event).EventHeader.ProviderId }
+                unsafe { (*event).provider_guid() }
             },
             None => { Guid::default() },
         }
@@ -103,7 +104,7 @@ impl AncillaryData {
     pub fn activity(&self) -> Guid {
         match self.event {
             Some(event) => {
-                unsafe { (*event).EventHeader.ActivityId }
+                unsafe { (*event).activity_guid() }
             },
             None => { Guid::default() },
         }
@@ -1178,10 +1179,10 @@ impl EtwSession {
         let has_cpu_filter = target_cpus.is_some();
 
         let result = session.process(Box::new(move |event| {
-            let cpu_index = event.ProcessorIndex;
+            let cpu_index = event.processor_index();
 
             /* Find events by provider ID */
-            if let Some(provider_events) = events.get_mut(&event.EventHeader.ProviderId) {
+            if let Some(provider_events) = events.get_mut(&event.provider_guid()) {
                 /* Determine which ID for lookup */
                 let id: usize = match provider_events.use_op_id() {
                     true => { event.EventHeader.EventDescriptor.Opcode.into() },

--- a/record-trace/Cargo.lock
+++ b/record-trace/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
  "sha1",
  "tracing",
  "twox-hash",
+ "windows-sys 0.59.0",
  "winreg",
 ]
 

--- a/record-trace/engine/Cargo.lock
+++ b/record-trace/engine/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
  "sha1",
  "tracing",
  "twox-hash",
+ "windows-sys 0.59.0",
  "winreg",
 ]
 

--- a/record-trace/ffi/Cargo.lock
+++ b/record-trace/ffi/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
  "sha1",
  "tracing",
  "twox-hash",
+ "windows-sys 0.59.0",
  "winreg",
 ]
 


### PR DESCRIPTION
### Changes

Replaces four hand-rolled ETW types that surface (or will surface) on the crate's public API with re-exports from `windows-sys`:

- `EVENT_RECORD`
- `EVENT_HEADER`
- `EVENT_HEADER_EXTENDED_DATA_ITEM`
- `EVENT_DESCRIPTOR`

### Why

Precursor to the TDH decoder work tracked in #270. That decoder will take a `&EVENT_RECORD` from `AncillaryData::record()` and hand it to a TDH-based decode call. Sourcing the public types from `windows-sys` gives us a single type identity end to end and shrinks the `one_collect` crate's public API surface.

This was the open question I raised on #270, and this PR is following [Option B mentioned in the issue](https://github.com/microsoft/one-collect/issues/270#issuecomment-4483260376).

### Scope

Deliberately constrained to only the four public types. The rest of `etw/abi.rs` stays hand-rolled:

- All `extern "system"` blocks (`StartTraceW`, `ControlTraceW`, `EnableTraceEx2`, `OpenTraceW`, `ProcessTrace`, `CloseTrace`, `TraceQueryInformation`, `TraceSetInformation`, plus the privilege helpers and `GetActiveProcessorCount`).
- All internal-only structs (`EVENT_TRACE_PROPERTIES`, `WNODE_HEADER`, `ENABLE_TRACE_PARAMETERS`, `EVENT_FILTER_DESCRIPTOR`, `EVENT_TRACE_LOGFILE`, `TRACE_LOGFILE_HEADER`, `EVENT_TRACE`, `EVENT_TRACE_HEADER`, `TRACE_PROFILE_INTERVAL`, `TOKEN_PRIVILEGES`, `EVENT_FILTER_LEVEL_KW`, `CLASSIC_EVENT_ID`).
- All `TRACE_LEVEL_*` / `EVENT_CONTROL_CODE_*` / `EVENT_HEADER_EXT_TYPE_*` / `EVENT_ENABLE_PROPERTY_*` constants.
- `TraceSession`, `TraceEnable`, `TraceFilter`, `flush_trace`, `wide_string`.

A full migration of the FFI is a fair follow-up but out of scope here to keep this PR focused on the bare-minimum change the TDH work needs.

### Safety

The trait impl contains three `unsafe` operations, each backed by a `const _: () = assert!(...)` guard above the impl block so future `windows-sys` layout drift fails the build instead of producing wrong bytes silently:

- `provider_guid` / `activity_guid` transmute `windows_sys::core::GUID` → our `Guid`. Guarded by `size_of` + `align_of` equality asserts.
- `processor_index` reads `u16` out of a union arm. Guarded by an asserted `size_of == 2` and an `align_of >= align_of::<u16>()` on `ETW_BUFFER_CONTEXT_0`.

### Follow-ups (not in this PR)

- The TDH decoder itself (#270).
- Optional: migrate the rest of `etw/abi.rs`'s FFI to `windows-sys` in a focused later PR if we ever want to retire the hand-rolled extern blocks.