### PR TITLE
Mark internal methods as const fn

### DIFF
--- a/one_collect/src/event/mod.rs
+++ b/one_collect/src/event/mod.rs
@@ -301,7 +301,7 @@ impl DataField {
     ///
     /// # Returns
     /// - A new `DataField` instance.
-    fn new(
+    const fn new(
         start: u32,
         end: u32) -> Self {
         Self(start, end)
@@ -311,7 +311,7 @@ impl DataField {
     ///
     /// # Returns
     /// - The start position as usize.
-    fn start(&self) -> usize {
+    const fn start(&self) -> usize {
         self.0 as usize
     }
 
@@ -319,7 +319,7 @@ impl DataField {
     ///
     /// # Returns
     /// - The end position as usize.
-    fn end(&self) -> usize {
+    const fn end(&self) -> usize {
         self.1 as usize
     }
 }

--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -831,7 +831,7 @@ impl LinuxDotNetProvider {
         Ok(())
     }
 
-    fn ensure_keyword_level(
+    const fn ensure_keyword_level(
         &mut self,
         keyword: u64,
         level: u8) {

--- a/one_collect/src/helpers/dotnet/scripting/mod.rs
+++ b/one_collect/src/helpers/dotnet/scripting/mod.rs
@@ -136,7 +136,7 @@ impl DotNetEventGroup {
 
     pub fn level(&self) -> u8 { self.level }
 
-    fn update_keyword(
+    const fn update_keyword(
         &mut self,
         keyword: u64,
         level: u8) {
@@ -163,12 +163,12 @@ pub (crate) struct DotNetProviderFlags {
 }
 
 impl DotNetProviderFlags {
-    fn with_callstacks(&mut self) {
+    const fn with_callstacks(&mut self) {
         self.callstacks = true;
         self.callstack_keywords = u64::MAX;
     }
 
-    fn with_callstacks_for_keywords(
+    const fn with_callstacks_for_keywords(
         &mut self,
         keywords: u64) {
         self.callstacks = true;
@@ -205,9 +205,9 @@ pub (crate) struct DotNetScenario {
 }
 
 impl DotNetScenario {
-    fn with_records(&mut self) { self.record = true; }
+    const fn with_records(&mut self) { self.record = true; }
 
-    fn with_callstacks(&mut self) { self.callstacks = true; }
+    const fn with_callstacks(&mut self) { self.callstacks = true; }
 
     fn use_scenario(
         &mut self,

--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -220,44 +220,44 @@ impl ExportSampler {
         }
     }
 
-    fn override_version(
+    const fn override_version(
         &mut self,
         version: Option<u16>) {
         self.version_override = version;
     }
 
     #[allow(dead_code)]
-    fn override_id(
+    const fn override_id(
         &mut self,
         id: Option<usize>) {
         self.id_override = id;
     }
 
-    fn override_op_code(
+    const fn override_op_code(
         &mut self,
         op_code: Option<u16>) {
         self.op_code_override = op_code;
     }
 
-    fn override_span_id(
+    const fn override_span_id(
         &mut self,
         span_id: Option<[u8; 8]>) {
         self.span_id_override = span_id;
     }
 
-    fn override_trace_id(
+    const fn override_trace_id(
         &mut self,
         trace_id: Option<[u8; 16]>) {
         self.trace_id_override = trace_id;
     }
 
-    fn override_activity_id(
+    const fn override_activity_id(
         &mut self,
         activity_id: Option<[u8; 16]>) {
         self.activity_id_override = activity_id;
     }
 
-    fn override_related_activity_id(
+    const fn override_related_activity_id(
         &mut self,
         related_activity_id: Option<[u8; 16]>) {
         self.related_activity_id_override = related_activity_id;
@@ -433,7 +433,7 @@ pub struct ExportBuiltContext<'a> {
 }
 
 impl<'a> ExportBuiltContext<'a> {
-    fn new(
+    const fn new(
         exporter: &'a mut ExportMachine,
         event: &'a Event,
         session: &'a mut os::Session) -> Self {
@@ -446,9 +446,9 @@ impl<'a> ExportBuiltContext<'a> {
         }
     }
 
-    fn take_sample_kind(&mut self) -> Option<u16> { self.sample_kind.take() }
+    const fn take_sample_kind(&mut self) -> Option<u16> { self.sample_kind.take() }
 
-    fn take_record_type(&mut self) -> Option<u16> { self.record_type.take() }
+    const fn take_record_type(&mut self) -> Option<u16> { self.record_type.take() }
 
     pub fn event(&self) -> &Event { self.event }
 
@@ -666,7 +666,7 @@ pub struct ExportTraceContext<'a> {
 }
 
 impl<'a> ExportTraceContext<'a> {
-    fn new(
+    const fn new(
         sampler: Writable<ExportSampler>,
         proxy: Writable<ExportProxy>,
         sample_kind: u16,

--- a/one_collect/src/helpers/exporting/pe_file.rs
+++ b/one_collect/src/helpers/exporting/pe_file.rs
@@ -257,19 +257,19 @@ struct PEResData {
 }
 
 impl PEResEntry {
-    fn is_named(&self) -> bool {
+    const fn is_named(&self) -> bool {
         (self.name_id_offset & 0x80000000) != 0
     }
 
-    fn name_id_value(&self) -> u32 {
+    const fn name_id_value(&self) -> u32 {
         self.name_id_offset & 0x7FFFFFFF
     }
 
-    fn is_dir(&self) -> bool {
+    const fn is_dir(&self) -> bool {
         (self.dir_data_offset & 0x80000000) != 0
     }
 
-    fn dir_data_value(&self) -> u32 {
+    const fn dir_data_value(&self) -> u32 {
         self.dir_data_offset & 0x7FFFFFFF
     }
 }

--- a/one_collect/src/helpers/exporting/process.rs
+++ b/one_collect/src/helpers/exporting/process.rs
@@ -477,7 +477,7 @@ impl<'a> ExportProcessReplay<'a> {
         self.process.mappings().get(self.mapping_index)
     }
 
-    pub(crate) fn done(&self) -> bool { self.current_time == u64::MAX }
+    pub(crate) const fn done(&self) -> bool { self.current_time == u64::MAX }
 
     pub(crate) fn advance(&mut self) {
         /* Advance index by time */

--- a/one_collect/src/helpers/exporting/universal.rs
+++ b/one_collect/src/helpers/exporting/universal.rs
@@ -164,7 +164,7 @@ impl UniversalExporter {
             until)
     }
 
-    pub(crate) fn cpu_buf_bytes(&self) -> usize { self.cpu_buf_bytes }
+    pub(crate) const fn cpu_buf_bytes(&self) -> usize { self.cpu_buf_bytes }
 
     pub(crate) fn run_build_hooks(
         &mut self,
@@ -218,7 +218,7 @@ impl UniversalExporter {
         }
     }
 
-    pub(crate) fn settings_mut(&mut self) -> Option<&mut ExportSettings> {
+    pub(crate) const fn settings_mut(&mut self) -> Option<&mut ExportSettings> {
         self.settings.as_mut()
     }
 }

--- a/one_collect/src/helpers/uprobe.rs
+++ b/one_collect/src/helpers/uprobe.rs
@@ -16,7 +16,7 @@ pub struct UProbe<'a> {
 }
 
 impl<'a> UProbe<'a> {
-    fn new(
+    const fn new(
         probe_type: &'a str,
         name: &'a str,
         address: u64) -> Self {

--- a/one_collect/src/lib.rs
+++ b/one_collect/src/lib.rs
@@ -67,7 +67,7 @@ pub use pathbuf_ext::{PathBufInteger};
 pub type IOResult<T> = std::io::Result<T>;
 pub type IOError = std::io::Error;
 
-fn page_size_to_mask(page_size: u64) -> u64 {
+const fn page_size_to_mask(page_size: u64) -> u64 {
     !((page_size - 1) as u64)
 }
 

--- a/one_collect/src/perf_event/mod.rs
+++ b/one_collect/src/perf_event/mod.rs
@@ -516,7 +516,7 @@ impl PerfSession {
         self.read_timeout = timeout;
     }
 
-    pub(crate) fn capture_env_options_mut(&mut self) -> &mut CaptureEnvironmentOptions {
+    pub(crate) const fn capture_env_options_mut(&mut self) -> &mut CaptureEnvironmentOptions {
         &mut self.capture_env_options
     }
 

--- a/one_collect/src/perf_event/rb/mod.rs
+++ b/one_collect/src/perf_event/rb/mod.rs
@@ -309,7 +309,7 @@ impl<T> RingBufBuilder<T> {
     /// Sets `FLAG_WATERMARK` and `wakeup_events_watermark` on the
     /// underlying `perf_event_attr`. A value of `0` keeps the kernel
     /// default of waking on every event.
-    pub(crate) fn set_wakeup_watermark(&mut self, bytes: u32) {
+    pub(crate) const fn set_wakeup_watermark(&mut self, bytes: u32) {
         self.attributes.flags |= FLAG_WATERMARK;
         self.attributes.wakeup_events_watermark = bytes;
     }
@@ -611,7 +611,7 @@ impl<'a> CpuRingReader {
         reader
     }
 
-    fn slice(&self) -> &[u8] {
+    const fn slice(&self) -> &[u8] {
         unsafe {
             std::slice::from_raw_parts(
                 self.pages,

--- a/one_collect/src/scripting/mod.rs
+++ b/one_collect/src/scripting/mod.rs
@@ -220,7 +220,7 @@ impl ScriptEngine {
         }
     }
 
-    pub(crate) fn rhai_engine(&mut self) -> &mut Engine { &mut self.engine }
+    pub(crate) const fn rhai_engine(&mut self) -> &mut Engine { &mut self.engine }
 
     pub fn enable_os_scripting(&mut self) {
         self.os.enable(&mut self.engine);

--- a/ruwind/src/dwarf.rs
+++ b/ruwind/src/dwarf.rs
@@ -54,7 +54,7 @@ struct FrameState {
 }
 
 impl FrameState {
-    fn new(
+    const fn new(
         rva: u64,
         cfa_reg: u8,
         cfa_off: i16) -> Self {
@@ -157,7 +157,7 @@ struct FrameOptions {
 }
 
 impl FrameOptions {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             enc: DW_EH_PE_UDATA8 |
                  DW_EH_PE_ABSPTR,
@@ -179,7 +179,7 @@ pub struct FrameOffset {
 }
 
 impl FrameOffset {
-    fn new(
+    const fn new(
         rva: u64,
         fde: u64) -> Self {
         Self {
@@ -245,7 +245,7 @@ impl FrameOffset {
         self.state = STATE_INVALID;
     }
 
-    fn mark_valid(&mut self) {
+    const fn mark_valid(&mut self) {
         self.state = STATE_VALID;
     }
 

--- a/ruwind/src/elf.rs
+++ b/ruwind/src/elf.rs
@@ -153,7 +153,7 @@ impl<'a> ElfSymbolIterator<'a> {
         }
     }
 
-    fn page_size_to_mask(page_size: u64) -> u64 {
+    const fn page_size_to_mask(page_size: u64) -> u64 {
         !((page_size - 1) as u64)
     }
 
@@ -863,7 +863,7 @@ struct ElfSymbol32 {
 }
 
 impl ElfSymbol32 {
-    fn is_function(&self) -> bool {
+    const fn is_function(&self) -> bool {
         self.st_info & 0xf == STT_FUNC
     }
 }
@@ -880,7 +880,7 @@ struct ElfSymbol64 {
 }
 
 impl ElfSymbol64 {
-    fn is_function(&self) -> bool {
+    const fn is_function(&self) -> bool {
         self.st_info & 0xf == STT_FUNC
     }
 }


### PR DESCRIPTION
## Summary
Applies `const fn` to 40 internal (non-pub) methods across one_collect (33) and ruwind (7)

## Motivation
Marking eligible functions const gives the compiler more freedom to evaluate them at compile time and is the idiomatic Rust style guidance reflected by the lint. The list was generated mechanically by:

```
cargo clippy --all-targets -- -W clippy::missing_const_for_fn -A clippy::all
```

## Scope: why this change is safe
- **Internal only:** Every method touched is either a private `fn` or `pub(crate) fn`. No item in the published API surface of either crate is modified, so this cannot break downstream callers.
- **No semantic change:** const fn only restricts what the function body is allowed to do; it does not change runtime behavior, ABI, signature, lifetimes, or trait bounds for any call site.
- **No public API stability concerns:** For pub functions, adding `const` becomes part of the API contract (removing it later is a breaking change in practice). That reasoning does not apply here because none of the changed items are reachable outside their crate.