### PR TITLE
Expose per-CPU perf fds via `PerfSession::perf_fds()`

### DIFF
--- a/one_collect/src/perf_event/mod.rs
+++ b/one_collect/src/perf_event/mod.rs
@@ -3,6 +3,8 @@
 
 use std::fs::File;
 
+#[cfg(target_os = "linux")]
+use std::os::fd::BorrowedFd;
 use std::time::Duration;
 use std::array::TryFromSliceError;
 use std::collections::{HashSet, HashMap};
@@ -218,6 +220,13 @@ pub trait PerfDataSource {
     fn end_reading(&mut self);
 
     fn more(&self) -> bool;
+
+    /// Borrow the per-CPU perf file descriptors owned by this source,
+    /// paired with their CPU index. Returns an empty list for sources
+    /// that do not expose per-CPU perf fds (for example, mock or
+    /// in-process sources).
+    #[cfg(target_os = "linux")]
+    fn perf_fds(&self) -> Vec<(u32, BorrowedFd<'_>)> { Vec::new() }
 
     /// Take the in-process ring buffer writer for use by capture_environment.
     /// Returns None if no in-process ring buffer is available.
@@ -514,6 +523,35 @@ impl PerfSession {
         &mut self,
         timeout: Duration) {
         self.read_timeout = timeout;
+    }
+
+    /// Borrow the per-CPU perf file descriptors backing this session,
+    /// paired with their CPU index.
+    ///
+    /// Intended for consumers that want to wait on the perf fds directly
+    /// (for example via `epoll(2)` or `tokio::io::unix::AsyncFd`) instead
+    /// of relying on the built-in poll/sleep read loop. Pair this with
+    /// [`RingBufSessionBuilder::with_wakeup_watermark`]
+    /// to control how often the kernel marks the fds readable.
+    ///
+    /// Consumers using this with an async runtime (for example a
+    /// single-threaded Tokio `current_thread` runtime) must also call
+    /// [`Self::set_read_timeout`] with `Duration::ZERO`. The drain
+    /// methods ([`Self::parse_all`], [`Self::parse_for_duration`],
+    /// [`Self::parse_until`]) internally call
+    /// `std::thread::sleep(read_timeout)` when the ring is drained,
+    /// which would block the runtime thread and starve every other
+    /// task on it. With `read_timeout = 0` that sleep becomes a no-op
+    /// syscall and the consumer should drive successive drains from
+    /// fd readiness rather than from the drain method itself.
+    ///
+    /// Returned `BorrowedFd`s are tied to `&self`, so the session must
+    /// outlive any consumer that uses them. Sources that do not expose
+    /// per-CPU perf fds (mock or in-process sources) return an empty
+    /// list.
+    #[cfg(target_os = "linux")]
+    pub fn perf_fds(&self) -> Vec<(u32, BorrowedFd<'_>)> {
+        self.source.perf_fds()
     }
 
     pub(crate) const fn capture_env_options_mut(&mut self) -> &mut CaptureEnvironmentOptions {
@@ -1458,6 +1496,17 @@ mod tests {
 
         assert!(mock.read(timeout).is_none());
         assert!(!mock.more());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn perf_fds_empty_for_mock_source() {
+        /* The default PerfDataSource::perf_fds() impl returns an empty
+         * list; sources that don't manage per-CPU perf fds (such as
+         * MockData) must inherit that behavior. */
+        let mock = MockData::new(0, 0);
+        let session = PerfSession::new(Box::new(mock));
+        assert!(session.perf_fds().is_empty());
     }
 
     #[test]

--- a/one_collect/src/perf_event/rb/mod.rs
+++ b/one_collect/src/perf_event/rb/mod.rs
@@ -3,6 +3,8 @@
 
 use std::marker::PhantomData;
 use std::arch::asm;
+#[cfg(target_os = "linux")]
+use std::os::fd::BorrowedFd;
 use std::rc::Rc;
 
 #[cfg(target_os = "linux")]
@@ -796,6 +798,17 @@ impl CpuRingBuf {
             cpu: self.cpu,
             attributes: self.attributes.clone(),
         }
+    }
+
+    /// Borrow the per-CPU perf fd for the lifetime of `self`.
+    ///
+    /// Returns `None` if the buffer has not been opened yet.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn borrowed_fd(&self) -> Option<BorrowedFd<'_>> {
+        /* SAFETY: `self.fd` is an open file descriptor for the lifetime
+         * of this `CpuRingBuf`. The returned `BorrowedFd` is tied to
+         * `&self` so the caller cannot outlive it. */
+        self.fd.map(|fd| unsafe { BorrowedFd::borrow_raw(fd) })
     }
 
     fn read_id(&self) -> IOResult<u64> {

--- a/one_collect/src/perf_event/rb/source.rs
+++ b/one_collect/src/perf_event/rb/source.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#[cfg(target_os = "linux")]
+use std::os::fd::BorrowedFd;
+
 use tracing::{debug, info, trace, warn};
 
 use super::*;
@@ -1266,6 +1269,28 @@ impl PerfDataSource for RingBufDataSource {
         }
 
         self.enabled
+    }
+
+    #[cfg(target_os = "linux")]
+    fn perf_fds(&self) -> Vec<(u32, BorrowedFd<'_>)> {
+        /* Walk leader_ids in CPU order so consumers get a deterministic
+         * iteration order. Each leader's per-CPU ring is the one the
+         * kernel marks readable; non-leader event types redirect into
+         * the same ring via `PERF_EVENT_IOC_SET_OUTPUT`, so their fds are
+         * not separately wakeable and are intentionally not exposed. */
+        let mut cpus: Vec<u32> = self.leader_ids.keys().copied().collect();
+        cpus.sort_unstable();
+
+        let mut fds = Vec::with_capacity(cpus.len());
+        for cpu in cpus {
+            let leader_id = self.leader_ids[&cpu];
+            if let Some(buf) = self.ring_bufs.get(&leader_id) {
+                if let Some(fd) = buf.borrowed_fd() {
+                    fds.push((cpu, fd));
+                }
+            }
+        }
+        fds
     }
 
     fn take_in_process_writer(


### PR DESCRIPTION
Part of #254. Builds on the merged #276 (`with_wakeup_watermark`).

## Background

`one_collect`'s `PerfSession` is pull-based today: the consumer calls `parse_all()` / `parse_for_duration()`, and when no data is available `RingBufDataSource::read` does `std::thread::sleep(read_timeout)` and returns `None`. This is fine for a thread that can sit and poll, but it blocks the runtime thread for a `current_thread` Tokio task and offers no way to consume events event-driven.

The Linux perf subsystem can signal us directly: each per-CPU perf fd is marked readable when data lands in its ring buffer. PR #276 made that signal useful by letting callers configure the kernel's wakeup watermark (so wakeups are amortized instead of one-per-event). What was still missing was a way for the consumer to actually receive that signal: the fds were owned by `RingBufDataSource` with no public accessor.

## What this PR adds

A single new public method on `PerfSession`:

```rust
pub fn perf_fds(&self) -> Vec<(u32, BorrowedFd<'_>)>
```

paired with a default-empty trait method on `PerfDataSource` so non-perf sources (mock, in-process) inherit a correct empty implementation:

```rust
fn perf_fds(&self) -> Vec<(u32, BorrowedFd<'_>)> { Vec::new() }
```

`RingBufDataSource` overrides it, walking `leader_ids` in CPU order and yielding `(cpu, BorrowedFd<'_>)` for each per-CPU leader ring buffer.

Combined with #276, a consumer can now wait on the fds directly:

```rust
let session = RingBufSessionBuilder::new()
    .with_page_count(64)
    .with_target_cpu(cpu_id)
    .with_wakeup_watermark(4096)        // from #276
    .build()?;

session.set_read_timeout(Duration::ZERO);

let (_cpu, fd) = session.perf_fds().into_iter().next().unwrap();
let async_fd = AsyncFd::new(fd)?;

loop {
    let mut guard = async_fd.readable().await?;
    session.parse_for_duration(budget)?; // drain whatever is ready
    guard.clear_ready();
}
```

## Design notes

### Only leader fds are exposed

Each per-CPU leader ring buffer is the one the kernel marks readable when data lands. Non-leader event types (tracepoint, profiling, context-switch, page-fault, BPF) all redirect their output into the leader's ring via `PERF_EVENT_IOC_SET_OUTPUT`, so their fds are never independently wakeable. Exposing them would mislead an epoll consumer into registering fds that never fire. The accessor intentionally yields only the leaders, one per CPU.

### `BorrowedFd<'_>` tied to `&self`

The returned `BorrowedFd` carries the lifetime of `&PerfSession`. The consumer cannot accidentally outlive the session and use a closed fd. Drop semantics: `BorrowedFd::drop` is a no-op, so wrapping it in `tokio::io::unix::AsyncFd` (which deregisters from epoll on drop but does not close the inner fd unless its `Drop` does) leaves fd ownership with the session, which is the correct invariant.

### CPU iteration order

The keys of `leader_ids: HashMap<u32, u64>` are unordered. The implementation sorts by CPU before returning so the consumer gets deterministic iteration order across runs.

## What this PR does NOT do

It does not change the existing read loop. After this PR, a fd-driven consumer is possible, with two practical situations:

- **Single-CPU session** (one `PerfSession` targets one CPU via `with_target_cpu`): one fd, one `AsyncFd`, `parse_all` / `parse_for_duration` naturally scopes to that one ring. The only remaining wart is the trailing `thread::sleep(read_timeout)` at the end of each drain pass; setting `set_read_timeout(Duration::ZERO)` avoids a blocking sleep (the internal sleep call becomes an immediate no-op syscall), which is suitable for async consumers that drive draining from fd readiness.
- **Multi-CPU session**: there is no way to drain just the ring whose fd became readable, only `parse_all` which drains everything across all CPUs. That is correct but defeats the point of per-CPU readiness. Fixing this requires `PerfSession::parse_for_cpu(cpu)` plus a refactor of the existing time-ordered read loop. That work is the remaining step on #254 and will land in a follow-up PR.

## Compatibility

Purely additive. New public method on `PerfSession`, new default-impl method on the `PerfDataSource` trait. No existing call site changes behavior.