### PR TITLE
Tighten visibility:  →  for crate-internal items

### DIFF
--- a/one_collect/Cargo.toml
+++ b/one_collect/Cargo.toml
@@ -67,6 +67,9 @@ harness = false
 name = "kallsyms"
 harness = false
 
+[lints.rust]
+unreachable_pub = "deny"
+
 [lints.clippy]
 absurd_extreme_comparisons = "deny"
 almost_swapped = "deny"

--- a/one_collect/examples/perf_cpu.rs
+++ b/one_collect/examples/perf_cpu.rs
@@ -36,7 +36,7 @@ impl Utilization {
     }
 
     #[cfg(target_os = "linux")]
-    pub fn new(session: &mut PerfSession) -> Writable<Self> {
+    fn new(session: &mut PerfSession) -> Writable<Self> {
         let util = Writable::new(Self::create());
 
         /* CPU is ancillary data for perf_event_open */
@@ -66,7 +66,7 @@ impl Utilization {
         util
     }
 
-    pub fn report(&mut self) {
+    fn report(&mut self) {
         let mut all = 0u64;
 
         println!(concat!(

--- a/one_collect/src/etw/abi.rs
+++ b/one_collect/src/etw/abi.rs
@@ -105,50 +105,50 @@ const EVENT_FILTER_TYPE_EVENT_ID: u32 = 0x80000200;
 const EVENT_FILTER_TYPE_STACKWALK: u32 = 0x80001000;
 const EVENT_FILTER_TYPE_STACKWALK_LEVEL_KW: u32 = 0x80004000;
 
-pub const EVENT_ENABLE_PROPERTY_ENABLE_KEYWORD_0: u32 = 64u32;
-pub const EVENT_ENABLE_PROPERTY_ENABLE_SILOS: u32 = 1024u32;
-pub const EVENT_ENABLE_PROPERTY_EVENT_KEY: u32 = 256u32;
-pub const EVENT_ENABLE_PROPERTY_EXCLUDE_INPRIVATE: u32 = 512u32;
-pub const EVENT_ENABLE_PROPERTY_IGNORE_KEYWORD_0: u32 = 16u32;
-pub const EVENT_ENABLE_PROPERTY_PROCESS_START_KEY: u32 = 128u32;
-pub const EVENT_ENABLE_PROPERTY_PROVIDER_GROUP: u32 = 32u32;
-pub const EVENT_ENABLE_PROPERTY_PSM_KEY: u32 = 8u32;
-pub const EVENT_ENABLE_PROPERTY_SID: u32 = 1u32;
-pub const EVENT_ENABLE_PROPERTY_SOURCE_CONTAINER_TRACKING: u32 = 2048u32;
-pub const EVENT_ENABLE_PROPERTY_STACK_TRACE: u32 = 4u32;
-pub const EVENT_ENABLE_PROPERTY_TS_ID: u32 = 2u32;
+pub(super) const EVENT_ENABLE_PROPERTY_ENABLE_KEYWORD_0: u32 = 64u32;
+pub(super) const EVENT_ENABLE_PROPERTY_ENABLE_SILOS: u32 = 1024u32;
+pub(super) const EVENT_ENABLE_PROPERTY_EVENT_KEY: u32 = 256u32;
+pub(super) const EVENT_ENABLE_PROPERTY_EXCLUDE_INPRIVATE: u32 = 512u32;
+pub(super) const EVENT_ENABLE_PROPERTY_IGNORE_KEYWORD_0: u32 = 16u32;
+pub(super) const EVENT_ENABLE_PROPERTY_PROCESS_START_KEY: u32 = 128u32;
+pub(super) const EVENT_ENABLE_PROPERTY_PROVIDER_GROUP: u32 = 32u32;
+pub(super) const EVENT_ENABLE_PROPERTY_PSM_KEY: u32 = 8u32;
+pub(super) const EVENT_ENABLE_PROPERTY_SID: u32 = 1u32;
+pub(super) const EVENT_ENABLE_PROPERTY_SOURCE_CONTAINER_TRACKING: u32 = 2048u32;
+pub(super) const EVENT_ENABLE_PROPERTY_STACK_TRACE: u32 = 4u32;
+pub(super) const EVENT_ENABLE_PROPERTY_TS_ID: u32 = 2u32;
 
-pub const EVENT_HEADER_EXT_TYPE_CONTAINER_ID: u32 = 16u32;
-pub const EVENT_HEADER_EXT_TYPE_CONTROL_GUID: u32 = 14u32;
-pub const EVENT_HEADER_EXT_TYPE_EVENT_KEY: u32 = 10u32;
-pub const EVENT_HEADER_EXT_TYPE_EVENT_SCHEMA_TL: u32 = 11u32;
-pub const EVENT_HEADER_EXT_TYPE_INSTANCE_INFO: u32 = 4u32;
-pub const EVENT_HEADER_EXT_TYPE_MAX: u32 = 19u32;
-pub const EVENT_HEADER_EXT_TYPE_PEBS_INDEX: u32 = 7u32;
-pub const EVENT_HEADER_EXT_TYPE_PMC_COUNTERS: u32 = 8u32;
-pub const EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY: u32 = 13u32;
-pub const EVENT_HEADER_EXT_TYPE_PROV_TRAITS: u32 = 12u32;
-pub const EVENT_HEADER_EXT_TYPE_PSM_KEY: u32 = 9u32;
-pub const EVENT_HEADER_EXT_TYPE_QPC_DELTA: u32 = 15u32;
-pub const EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID: u32 = 1u32;
-pub const EVENT_HEADER_EXT_TYPE_SID: u32 = 2u32;
-pub const EVENT_HEADER_EXT_TYPE_STACK_KEY32: u32 = 17u32;
-pub const EVENT_HEADER_EXT_TYPE_STACK_KEY64: u32 = 18u32;
-pub const EVENT_HEADER_EXT_TYPE_STACK_TRACE32: u32 = 5u32;
-pub const EVENT_HEADER_EXT_TYPE_STACK_TRACE64: u32 = 6u32;
-pub const EVENT_HEADER_EXT_TYPE_TS_ID: u32 = 3u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_CONTAINER_ID: u32 = 16u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_CONTROL_GUID: u32 = 14u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_EVENT_KEY: u32 = 10u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_EVENT_SCHEMA_TL: u32 = 11u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_INSTANCE_INFO: u32 = 4u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_MAX: u32 = 19u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_PEBS_INDEX: u32 = 7u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_PMC_COUNTERS: u32 = 8u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY: u32 = 13u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_PROV_TRAITS: u32 = 12u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_PSM_KEY: u32 = 9u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_QPC_DELTA: u32 = 15u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID: u32 = 1u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_SID: u32 = 2u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_STACK_KEY32: u32 = 17u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_STACK_KEY64: u32 = 18u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_STACK_TRACE32: u32 = 5u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_STACK_TRACE64: u32 = 6u32;
+pub(super) const EVENT_HEADER_EXT_TYPE_TS_ID: u32 = 3u32;
 
-pub const TRACE_LEVEL_CRITICAL: u8 = 1;
-pub const TRACE_LEVEL_ERROR: u8 = 2;
-pub const TRACE_LEVEL_WARNING: u8 = 3;
-pub const TRACE_LEVEL_INFORMATION: u8 = 4;
-pub const TRACE_LEVEL_VERBOSE: u8 = 5;
+pub(super) const TRACE_LEVEL_CRITICAL: u8 = 1;
+pub(super) const TRACE_LEVEL_ERROR: u8 = 2;
+pub(super) const TRACE_LEVEL_WARNING: u8 = 3;
+pub(super) const TRACE_LEVEL_INFORMATION: u8 = 4;
+pub(super) const TRACE_LEVEL_VERBOSE: u8 = 5;
 
-pub const EVENT_CONTROL_CODE_DISABLE_PROVIDER: u32 = 0;
-pub const EVENT_CONTROL_CODE_ENABLE_PROVIDER: u32 = 1;
-pub const EVENT_CONTROL_CODE_CAPTURE_STATE: u32 = 2;
+pub(super) const EVENT_CONTROL_CODE_DISABLE_PROVIDER: u32 = 0;
+pub(super) const EVENT_CONTROL_CODE_ENABLE_PROVIDER: u32 = 1;
+pub(super) const EVENT_CONTROL_CODE_CAPTURE_STATE: u32 = 2;
 
-pub fn wide_string(
+pub(super) fn wide_string(
     name: &str) -> Vec<u16> {
     let mut name_wide: Vec<u16> = Vec::new();
 
@@ -217,14 +217,14 @@ impl Default for WNODE_HEADER {
 
 #[repr(C)]
 #[allow(non_snake_case)]
-pub struct CLASSIC_EVENT_ID {
+pub(super) struct CLASSIC_EVENT_ID {
     pub EventGuid: Guid,
     pub Type: u8,
     pub Reserved: [u8; 7],
 }
 
 impl CLASSIC_EVENT_ID {
-    pub fn new(
+    pub(super) fn new(
         provider: Guid,
         id: u8) -> Self {
         Self {
@@ -470,7 +470,7 @@ impl Default for ENABLE_TRACE_PARAMETERS {
 // surface (`EVENT_TRACE_PROPERTIES`, `WNODE_HEADER`, `ENABLE_TRACE_PARAMETERS`,
 // the extern entry points, etc.) is internal-only and stays hand-rolled
 // to keep the migration localized.
-pub use windows_sys::Win32::System::Diagnostics::Etw::{
+pub(super) use windows_sys::Win32::System::Diagnostics::Etw::{
     EVENT_HEADER_EXTENDED_DATA_ITEM,
     EVENT_RECORD,
 };
@@ -588,7 +588,7 @@ impl EventRecordExt for EVENT_RECORD {
     }
 }
 
-pub struct TraceFilter {
+pub(super) struct TraceFilter {
     filter_type: u32,
     filter_data: Vec<u8>,
 }
@@ -838,7 +838,7 @@ pub(crate) fn flush_trace(handle: u64) {
     }
 }
 
-pub struct TraceSession {
+pub(super) struct TraceSession {
     properties: EVENT_TRACE_PROPERTIES,
     name: String,
     handle: u64,
@@ -862,7 +862,7 @@ extern "C" fn event_callback(record: *const EVENT_RECORD) {
 }
 
 impl TraceSession {
-    pub fn new(
+    pub(super) fn new(
         name: String,
         buf_size_kb: u32) -> Self {
         let mut session = Self {
@@ -876,11 +876,11 @@ impl TraceSession {
         session
     }
 
-    pub fn handle(&self) -> u64 { self.handle }
+    pub(super) fn handle(&self) -> u64 { self.handle }
 
-    pub fn id(&self) -> u64 { self.properties.Wnode.HistoricalContext }
+    pub(super) fn id(&self) -> u64 { self.properties.Wnode.HistoricalContext }
 
-    pub fn start(
+    pub(super) fn start(
         &mut self) -> anyhow::Result<()> {
         let trace_name = wide_string(&self.name);
 
@@ -947,7 +947,7 @@ impl TraceSession {
         }
     }
 
-    pub fn process(
+    pub(super) fn process(
         &self,
         parse: Box<dyn FnMut(&EVENT_RECORD)>) -> anyhow::Result<()> {
         /* Create thin pointer */
@@ -981,7 +981,7 @@ impl TraceSession {
         Ok(())
     }
 
-    pub fn remote_stop(
+    pub(super) fn remote_stop(
         handle: u64) {
         let mut properties = EVENT_TRACE_PROPERTIES::default();
 
@@ -994,7 +994,7 @@ impl TraceSession {
         }
     }
 
-    pub fn stop(
+    pub(super) fn stop(
         &mut self) {
         unsafe {
             ControlTraceW(
@@ -1005,7 +1005,7 @@ impl TraceSession {
         }
     }
 
-    pub fn enable_kernel_callstacks(
+    pub(super) fn enable_kernel_callstacks(
         &self,
         events: &Vec<CLASSIC_EVENT_ID>) -> anyhow::Result<()> {
         unsafe {
@@ -1025,7 +1025,7 @@ impl TraceSession {
         Ok(())
     }
 
-    pub fn set_profile_interval(
+    pub(super) fn set_profile_interval(
         &self,
         milliseconds: u32) -> anyhow::Result<()> {
         let mut interval = TRACE_PROFILE_INTERVAL {
@@ -1066,7 +1066,7 @@ impl TraceSession {
         Ok(())
     }
 
-    pub fn enable_privilege(
+    pub(super) fn enable_privilege(
         &self,
         name: &str) -> bool {
         let mut id: u64 = 0;

--- a/one_collect/src/etw/events.rs
+++ b/one_collect/src/etw/events.rs
@@ -23,7 +23,7 @@ fn register_soft_pid(
     }
 }
 
-pub fn comm(
+pub(super) fn comm(
     id: usize,
     name: &str) -> Event {
     let mut event = Event::new(id, name.into());
@@ -97,7 +97,7 @@ pub fn comm(
     event
 }
 
-pub fn mmap(
+pub(super) fn mmap(
     id: usize,
     name: &str) -> Event {
     let mut event = Event::new(id, name.into());
@@ -170,7 +170,7 @@ pub fn mmap(
     event
 }
 
-pub fn sample_profile(
+pub(super) fn sample_profile(
     id: usize,
     name: &str) -> Event {
     let mut event = Event::new(id, name.into());
@@ -203,7 +203,7 @@ pub fn sample_profile(
     event
 }
 
-pub fn dpc(
+pub(super) fn dpc(
     id: usize,
     name: &str) -> Event {
     let mut event = Event::new(id, name.into());
@@ -229,7 +229,7 @@ pub fn dpc(
     event
 }
 
-pub fn callstack(
+pub(super) fn callstack(
     id: usize,
     name: &str) -> Event {
     let mut event = Event::new(id, name.into());
@@ -270,7 +270,7 @@ pub fn callstack(
     event
 }
 
-pub fn ready_thread(
+pub(super) fn ready_thread(
     id: usize,
     name: &str) -> Event {
     let mut event = Event::new(id, name.into());
@@ -307,7 +307,7 @@ pub fn ready_thread(
     event
 }
 
-pub fn cswitch(
+pub(super) fn cswitch(
     id: usize,
     name: &str) -> Event {
     let mut event = Event::new(id, name.into());
@@ -380,7 +380,7 @@ pub fn cswitch(
     event
 }
 
-pub fn hard_page_fault(
+pub(super) fn hard_page_fault(
     id: usize,
     name: &str) -> Event {
     let mut event = Event::new(id, name.into());
@@ -427,7 +427,7 @@ pub fn hard_page_fault(
     event
 }
 
-pub fn soft_page_fault(
+pub(super) fn soft_page_fault(
     id: usize,
     name: &str) -> Event {
     let mut event = Event::new(id, name.into());

--- a/one_collect/src/helpers/dotnet/nettrace.rs
+++ b/one_collect/src/helpers/dotnet/nettrace.rs
@@ -6,9 +6,9 @@
 
 const EMPTY: &[u8] = &[];
 
-pub const LABEL_META: u8 = 1;
-pub const LABEL_ACTIVITY: u8 = 2;
-pub const LABEL_RELATED_ACTIVITY: u8 = 3;
+pub(crate) const LABEL_META: u8 = 1;
+pub(crate) const LABEL_ACTIVITY: u8 = 2;
+pub(crate) const LABEL_RELATED_ACTIVITY: u8 = 3;
 
 const U32_LEN: usize = 4;
 const U64_LEN: usize = 8;
@@ -16,7 +16,7 @@ const GUID_LEN: usize = 16;
 
 use crate::event::{LocationType, EventFormat, EventField};
 
-pub fn parse_event_extension_v1(
+pub(crate) fn parse_event_extension_v1(
     data: &[u8],
     mut output: impl FnMut(u8, &[u8])) {
     let mut extension = data;
@@ -92,7 +92,7 @@ pub fn parse_event_extension_v1(
     }
 }
 
-pub struct FieldsParserV5 {
+pub(crate) struct FieldsParserV5 {
 }
 
 struct FieldType {
@@ -451,7 +451,7 @@ impl FieldsParserV5 {
         fields
     }
 
-    pub fn parse(mut fields: &[u8]) -> EventFormat {
+    pub(crate) fn parse(mut fields: &[u8]) -> EventFormat {
         let mut format = EventFormat::default();
 
         Self::parse_object(fields, &mut format, 1);
@@ -460,7 +460,7 @@ impl FieldsParserV5 {
     }
 }
 
-pub struct MetaParserV5<'a> {
+pub(crate) struct MetaParserV5<'a> {
     provider_name: &'a [u8],
     event_id: &'a [u8],
     event_name: &'a [u8],
@@ -471,11 +471,11 @@ pub struct MetaParserV5<'a> {
 }
 
 impl<'a> MetaParserV5<'a> {
-    pub fn event_id(&self) -> Option<u32> {
+    pub(crate) fn event_id(&self) -> Option<u32> {
         Self::read_int(self.event_id)
     }
 
-    pub fn provider_name(
+    pub(crate) fn provider_name(
         &self,
         output: &mut String) {
         output.clear();
@@ -485,7 +485,7 @@ impl<'a> MetaParserV5<'a> {
             output);
     }
 
-    pub fn event_name(
+    pub(crate) fn event_name(
         &self,
         output: &mut String) {
         output.clear();
@@ -495,19 +495,19 @@ impl<'a> MetaParserV5<'a> {
             output);
     }
 
-    pub fn keywords(&self) -> Option<u64> {
+    pub(crate) fn keywords(&self) -> Option<u64> {
         Self::read_long(self.keywords)
     }
 
-    pub fn version(&self) -> Option<u32> {
+    pub(crate) fn version(&self) -> Option<u32> {
         Self::read_int(self.version)
     }
 
-    pub fn level(&self) -> Option<u32> {
+    pub(crate) fn level(&self) -> Option<u32> {
         Self::read_int(self.level)
     }
 
-    pub fn fields(&self) -> &'a [u8] { self.fields }
+    pub(crate) fn fields(&self) -> &'a [u8] { self.fields }
 
     fn push_unicode_string(
         data: &[u8],
@@ -563,7 +563,7 @@ impl<'a> MetaParserV5<'a> {
         }
     }
 
-    pub fn parse(data: &'a [u8]) -> Self {
+    pub(crate) fn parse(data: &'a [u8]) -> Self {
         let mut buffer = data;
 
         /* ProviderName */

--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -558,7 +558,7 @@ pub(crate) struct OSDotNetHelper {
 }
 
 impl OSDotNetHelper {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             perf_maps: false,
             perf_map_procs: None,
@@ -697,15 +697,15 @@ impl Default for LinuxDotNetProvider {
 }
 
 impl LinuxDotNetProvider {
-    pub fn has_named_events(&self) -> bool {
+    pub(crate) fn has_named_events(&self) -> bool {
         !self.named_events.is_empty()
     }
 
-    pub fn has_callbacks(&self) -> bool {
+    pub(crate) fn has_callbacks(&self) -> bool {
         !self.callbacks.is_empty()
     }
 
-    pub fn set_filter_args(
+    pub(crate) fn set_filter_args(
         &mut self,
         filter_args: String) -> anyhow::Result<()> {
         if self.filter_args.is_some() {
@@ -717,7 +717,7 @@ impl LinuxDotNetProvider {
         Ok(())
     }
 
-    pub fn record_provider(
+    pub(crate) fn record_provider(
         &mut self,
         provider_name: &str,
         keyword: u64,
@@ -842,7 +842,7 @@ impl LinuxDotNetProvider {
         }
     }
 
-    pub fn add_named_event(
+    pub(crate) fn add_named_event(
         &mut self,
         name: String,
         event: LinuxDotNetEvent,
@@ -866,7 +866,7 @@ impl LinuxDotNetProvider {
             .push(event);
     }
 
-    pub fn add_event(
+    pub(crate) fn add_event(
         &mut self,
         dotnet_id: usize,
         event: LinuxDotNetEvent) {
@@ -878,7 +878,7 @@ impl LinuxDotNetProvider {
             .push(event);
     }
 
-    pub fn proxy_id_to_events(
+    pub(crate) fn proxy_id_to_events(
         &self,
         proxy_id_set: &HashSet<usize>,
         dotnet_id_set: &mut HashSet<usize>) {
@@ -905,7 +905,7 @@ struct DotNetEventDesc {
 }
 
 impl DotNetEventDesc {
-    pub fn new(name: &str) -> Self {
+    pub(crate) fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
         }
@@ -1118,14 +1118,14 @@ pub(crate) struct OSDotNetEventFactory {
 }
 
 impl OSDotNetEventFactory {
-    pub fn new(proxy: impl FnMut(String, usize) -> Option<Event> + 'static) -> Self {
+    pub(crate) fn new(proxy: impl FnMut(String, usize) -> Option<Event> + 'static) -> Self {
         Self {
             proxy: Box::new(proxy),
             providers: Writable::new(HashMap::new()),
         }
     }
 
-    pub fn hook_to_exporter(
+    pub(crate) fn hook_to_exporter(
         &mut self,
         exporter: UniversalExporter) -> UniversalExporter {
         let fn_providers = self.providers.clone();
@@ -1356,7 +1356,7 @@ impl OSDotNetEventFactory {
         })
     }
 
-    pub fn record_provider(
+    pub(crate) fn record_provider(
         &mut self,
         provider_name: &str,
         keyword: u64,
@@ -1370,7 +1370,7 @@ impl OSDotNetEventFactory {
             .record_provider(provider_name, keyword, level, flags)
     }
 
-    pub fn set_filter_args(
+    pub(crate) fn set_filter_args(
         &mut self,
         provider_name: &str,
         filter_args: String) -> anyhow::Result<()> {
@@ -1382,7 +1382,7 @@ impl OSDotNetEventFactory {
             .set_filter_args(filter_args)
     }
 
-    pub fn new_event(
+    pub(crate) fn new_event(
         &mut self,
         provider_name: &str,
         keyword: u64,

--- a/one_collect/src/helpers/dotnet/os/windows.rs
+++ b/one_collect/src/helpers/dotnet/os/windows.rs
@@ -35,7 +35,7 @@ pub(crate) struct OSDotNetHelper {
 }
 
 impl OSDotNetHelper {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             jit_symbols: false,
         }
@@ -67,7 +67,7 @@ pub(crate) struct OSDotNetEventFactory {
 impl OSDotNetEventFactory {
     const ETW_REG_PUB_KEY: &'static str = "SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Winevt\\Publishers";
 
-    pub fn new(_proxy: impl FnMut(String, usize) -> Option<Event> + 'static) -> Self {
+    pub(crate) fn new(_proxy: impl FnMut(String, usize) -> Option<Event> + 'static) -> Self {
         Self {
             filter_args: Writable::new(Some(HashMap::new())),
             record_events: Writable::new(Some(Vec::new())),
@@ -161,7 +161,7 @@ impl OSDotNetEventFactory {
             });
     }
 
-    pub fn hook_to_exporter(
+    pub(crate) fn hook_to_exporter(
         &mut self,
         exporter: UniversalExporter) -> UniversalExporter {
         let filter_args = self.filter_args.clone();
@@ -294,7 +294,7 @@ impl OSDotNetEventFactory {
         })
     }
 
-    pub fn record_provider(
+    pub(crate) fn record_provider(
         &mut self,
         provider_name: &str,
         keyword: u64,
@@ -327,7 +327,7 @@ impl OSDotNetEventFactory {
         Ok(())
     }
 
-    pub fn set_filter_args(
+    pub(crate) fn set_filter_args(
         &mut self,
         provider_name: &str,
         filter_args: String) -> anyhow::Result<()> {
@@ -354,7 +354,7 @@ impl OSDotNetEventFactory {
         }
     }
 
-    pub fn new_event(
+    pub(crate) fn new_event(
         &mut self,
         provider_name: &str,
         keyword: u64,

--- a/one_collect/src/helpers/dotnet/scripting/mod.rs
+++ b/one_collect/src/helpers/dotnet/scripting/mod.rs
@@ -115,9 +115,9 @@ pub (crate) struct DotNetSample {
 }
 
 impl DotNetSample {
-    pub fn record(&self) -> bool { self.record }
+    pub(crate) fn record(&self) -> bool { self.record }
 
-    pub fn take(self) -> (Event, Box<dyn FnMut(&[u8]) -> anyhow::Result<MetricValue>>) {
+    pub(crate) fn take(self) -> (Event, Box<dyn FnMut(&[u8]) -> anyhow::Result<MetricValue>>) {
         (self.event, self.sample_value)
     }
 }
@@ -130,11 +130,11 @@ pub (crate) struct DotNetEventGroup {
 }
 
 impl DotNetEventGroup {
-    pub fn events(&self) -> &Vec<DotNetEvent> { &self.events }
+    pub(crate) fn events(&self) -> &Vec<DotNetEvent> { &self.events }
 
-    pub fn keyword(&self) -> u64 { self.keyword }
+    pub(crate) fn keyword(&self) -> u64 { self.keyword }
 
-    pub fn level(&self) -> u8 { self.level }
+    pub(crate) fn level(&self) -> u8 { self.level }
 
     const fn update_keyword(
         &mut self,
@@ -176,10 +176,10 @@ impl DotNetProviderFlags {
     }
 
     #[allow(dead_code)]
-    pub fn callstacks(&self) -> bool { self.callstacks }
+    pub(crate) fn callstacks(&self) -> bool { self.callstacks }
 
     #[allow(dead_code)]
-    pub fn callstack_keywords(&self) -> u64 { self.callstack_keywords }
+    pub(crate) fn callstack_keywords(&self) -> u64 { self.callstack_keywords }
 }
 
 impl CustomType for DotNetProviderFlags {

--- a/one_collect/src/helpers/dotnet/scripting/runtime.rs
+++ b/one_collect/src/helpers/dotnet/scripting/runtime.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::event::*;
 
 impl DotNetScenario {
-    pub fn build_runtime(builder: &mut TypeBuilder<Self>) {
+    pub(crate) fn build_runtime(builder: &mut TypeBuilder<Self>) {
         builder
             .with_fn("with_exceptions", Self::with_exceptions)
             .with_fn("with_gc_times", Self::with_gc_times)
@@ -24,7 +24,7 @@ impl DotNetScenario {
             .with_fn("with_arm_allocs", Self::with_arm_allocs);
     }
 
-    pub fn add_runtime_samples(
+    pub(crate) fn add_runtime_samples(
         &self,
         factory: &mut OSDotNetEventFactory,
         mut add_sample: impl FnMut(DotNetSample)) {
@@ -1209,7 +1209,7 @@ impl DotNetScenario {
         }
     }
 
-    pub fn with_arm_threads(&mut self) {
+    pub(crate) fn with_arm_threads(&mut self) {
         /* Created */
         self.runtime.add(
             DotNetEvent {
@@ -1235,7 +1235,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_arm_allocs(&mut self) {
+    pub(crate) fn with_arm_allocs(&mut self) {
         /* Alloc */
         self.runtime.add(
             DotNetEvent {
@@ -1253,7 +1253,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_tp_worker_threads(&mut self) {
+    pub(crate) fn with_tp_worker_threads(&mut self) {
         /* Start */
         self.runtime.add(
             DotNetEvent {
@@ -1287,7 +1287,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_tp_worker_thread_adjustments(&mut self) {
+    pub(crate) fn with_tp_worker_thread_adjustments(&mut self) {
         /* Sample */
         self.runtime.add(
             DotNetEvent {
@@ -1313,7 +1313,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_tp_io_threads(&mut self) {
+    pub(crate) fn with_tp_io_threads(&mut self) {
         /* Retire */
         self.runtime.add(
             DotNetEvent {
@@ -1339,7 +1339,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_contentions(&mut self) {
+    pub(crate) fn with_contentions(&mut self) {
         /* Start */
         self.runtime.add(
             DotNetEvent {
@@ -1357,7 +1357,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_exceptions(&mut self) {
+    pub(crate) fn with_exceptions(&mut self) {
         self.runtime.add(
             DotNetEvent {
                 id: 80,
@@ -1366,7 +1366,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_gc_finalizers(&mut self) {
+    pub(crate) fn with_gc_finalizers(&mut self) {
         /* Start */
         self.runtime.add(
             DotNetEvent {
@@ -1384,7 +1384,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_gc_suspends(&mut self) {
+    pub(crate) fn with_gc_suspends(&mut self) {
         /* Start */
         self.runtime.add(
             DotNetEvent {
@@ -1402,7 +1402,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_gc_restarts(&mut self) {
+    pub(crate) fn with_gc_restarts(&mut self) {
         /* Start */
         self.runtime.add(
             DotNetEvent {
@@ -1420,7 +1420,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_gc_concurrent_threads(&mut self) {
+    pub(crate) fn with_gc_concurrent_threads(&mut self) {
         /* Create */
         self.runtime.add(
             DotNetEvent {
@@ -1438,7 +1438,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_gc_segments(&mut self) {
+    pub(crate) fn with_gc_segments(&mut self) {
         /* Create */
         self.runtime.add(
             DotNetEvent {
@@ -1456,7 +1456,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_gc_allocs(&mut self) {
+    pub(crate) fn with_gc_allocs(&mut self) {
         self.runtime.add(
             DotNetEvent {
                 id: 10,
@@ -1465,7 +1465,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_gc_stats(&mut self) {
+    pub(crate) fn with_gc_stats(&mut self) {
         self.runtime.add(
             DotNetEvent {
                 id: 4,
@@ -1474,7 +1474,7 @@ impl DotNetScenario {
             });
     }
 
-    pub fn with_gc_times(&mut self) {
+    pub(crate) fn with_gc_times(&mut self) {
         self.runtime.add(
             DotNetEvent {
                 id: 1,

--- a/one_collect/src/helpers/exporting/lookup.rs
+++ b/one_collect/src/helpers/exporting/lookup.rs
@@ -10,7 +10,7 @@ pub(crate) struct AddressLookupItem {
 }
 
 impl AddressLookupItem {
-    pub fn new(
+    pub(crate) fn new(
         address: u64,
         index: u32,
         valid: bool) -> Self {
@@ -29,11 +29,11 @@ pub(crate) struct AddressLookup {
 }
 
 impl AddressLookup {
-    pub fn is_empty(&self) -> bool { self.lookup.is_empty() }
+    pub(crate) fn is_empty(&self) -> bool { self.lookup.is_empty() }
 
-    pub fn clear(&mut self) { self.lookup.clear(); }
+    pub(crate) fn clear(&mut self) { self.lookup.clear(); }
 
-    pub fn find(
+    pub(crate) fn find(
         &mut self,
         address: u64) -> &[u32] {
         let mut index = self.lookup.partition_point(
@@ -59,7 +59,7 @@ impl AddressLookup {
         &self.index
     }
 
-    pub fn update(
+    pub(crate) fn update(
         &mut self,
         items: &mut Vec<AddressLookupItem>) {
         let mut index_set = HashSet::new();

--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -384,34 +384,34 @@ impl ExportSampler {
         Ok(self.exporter.borrow_mut().span_to_value(span))
     }
 
-    pub fn label_attribute(
+    pub(crate) fn label_attribute(
         &mut self,
         name: &str,
         label: &str) -> ExportAttributePair {
         self.exporter.borrow_mut().label_attribute(name, label)
     }
 
-    pub fn value_attribute(
+    pub(crate) fn value_attribute(
         &mut self,
         name: &str,
         value: u64) -> ExportAttributePair {
         self.exporter.borrow_mut().value_attribute(name, value)
     }
 
-    pub fn record_type(
+    pub(crate) fn record_type(
         &mut self,
         record_type: ExportRecordType) -> u16 {
         self.exporter.borrow_mut().record_type(record_type)
     }
 
-    pub fn record_data(
+    pub(crate) fn record_data(
         &mut self,
         record_type_id: u16,
         data: &[u8]) ->usize {
         self.exporter.borrow_mut().record_data(record_type_id, data)
     }
 
-    pub fn kind(
+    pub(crate) fn kind(
         &mut self,
         kind: &str) -> u16 {
         self.exporter.borrow_mut().sample_kind(kind)

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -43,7 +43,7 @@ pub(crate) struct OSExportProcess {
 }
 
 impl OSExportProcess {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             root_fs: None,
         }
@@ -633,7 +633,7 @@ pub(crate) struct OSExportSettings {
 }
 
 impl OSExportSettings {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             process_fs: true,
         }
@@ -759,7 +759,7 @@ pub(crate) struct OSExportMachine {
 }
 
 impl OSExportMachine {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             cswitches: HashMap::new(),
             dev_nodes: ExportDevNodeLookup::new(),
@@ -1345,7 +1345,7 @@ struct ExportDevNodeLookup {
 }
 
 impl ExportDevNodeLookup {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             fds: HashMap::new(),
         }
@@ -1363,7 +1363,7 @@ impl ExportDevNodeLookup {
         self.fds.entry(key)
     }
 
-    pub fn open(
+    pub(crate) fn open(
         &self,
         node: &ExportDevNode) -> Option<File> {
         match self.fds.get(node) {

--- a/one_collect/src/helpers/exporting/os/windows.rs
+++ b/one_collect/src/helpers/exporting/os/windows.rs
@@ -48,7 +48,7 @@ pub(crate) struct OSExportSettings {
 }
 
 impl OSExportSettings {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
         }
     }
@@ -60,7 +60,7 @@ pub(crate) struct OSExportProcess {
 }
 
 impl OSExportProcess {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
         }
     }
@@ -201,7 +201,7 @@ struct CpuProfile {
 }
 
 impl CpuProfile {
-    pub fn new(
+    pub(crate) fn new(
         cpu: u32,
         ip: u64) -> Self {
         Self {
@@ -218,7 +218,7 @@ struct CpuProfileKey {
 }
 
 impl CpuProfileKey {
-    pub fn new(
+    pub(crate) fn new(
         time: u64,
         tid: u32) -> Self {
         Self {
@@ -252,7 +252,7 @@ pub(crate) struct OSExportMachine {
 }
 
 impl OSExportMachine {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             cswitches: HashMap::new(),
             faults: HashMap::new(),
@@ -263,7 +263,7 @@ impl OSExportMachine {
         }
     }
 
-    pub fn alloc_idle_pid(machine: &mut ExportMachine) {
+    pub(crate) fn alloc_idle_pid(machine: &mut ExportMachine) {
         /* Always allocate global idle pid as NsPid 0 */
         machine.os.global_idle_pid = machine.os.alloc_global_pid(0);
 
@@ -271,7 +271,7 @@ impl OSExportMachine {
         *machine.process_mut(machine.os.global_idle_pid).ns_pid_mut() = Some(0);
     }
 
-    pub fn get_or_alloc_global_pid(
+    pub(crate) fn get_or_alloc_global_pid(
         &mut self,
         local_pid: u32) -> u32 {
         match self.get_global_pid(local_pid) {
@@ -280,7 +280,7 @@ impl OSExportMachine {
         }
     }
 
-    pub fn get_global_pid(
+    pub(crate) fn get_global_pid(
         &self,
         local_pid: u32) -> Option<u32> {
         match self.pid_mapping.get(&local_pid) {
@@ -289,7 +289,7 @@ impl OSExportMachine {
         }
     }
 
-    pub fn alloc_global_pid(
+    pub(crate) fn alloc_global_pid(
         &mut self,
         local_pid: u32) -> u32 {
         let global_pid = self.new_global_pid();
@@ -300,7 +300,7 @@ impl OSExportMachine {
             .or_insert(global_pid)
     }
 
-    pub fn new_global_pid(
+    pub(crate) fn new_global_pid(
         &mut self) -> u32 {
         let global_pid = self.pid_index;
 

--- a/one_collect/src/helpers/exporting/record.rs
+++ b/one_collect/src/helpers/exporting/record.rs
@@ -93,7 +93,7 @@ pub(crate) struct ExportRecord {
 }
 
 impl ExportRecord {
-    pub fn new(
+    pub(crate) fn new(
         record_type: u16,
         offset: usize,
         length: u32) -> Self {
@@ -104,9 +104,9 @@ impl ExportRecord {
         }
     }
 
-    pub fn record_type(&self) -> u16 { self.record_type }
+    pub(crate) fn record_type(&self) -> u16 { self.record_type }
 
-    pub fn start(&self) -> usize { self.offset }
+    pub(crate) fn start(&self) -> usize { self.offset }
 
-    pub fn end(&self) -> usize { self.offset + self.length as usize }
+    pub(crate) fn end(&self) -> usize { self.offset + self.length as usize }
 }

--- a/one_collect/src/helpers/exporting/scripting.rs
+++ b/one_collect/src/helpers/exporting/scripting.rs
@@ -366,31 +366,31 @@ impl ScriptTimeline {
         }
     }
 
-    pub fn with_min_ns(
+    pub(crate) fn with_min_ns(
         &mut self,
         nanos: i64) {
         self.timeline.borrow_mut().set_min_duration(Duration::from_nanos(nanos as u64));
     }
 
-    pub fn with_min_us(
+    pub(crate) fn with_min_us(
         &mut self,
         micros: i64) {
         self.timeline.borrow_mut().set_min_duration(Duration::from_micros(micros as u64));
     }
 
-    pub fn with_min_ms(
+    pub(crate) fn with_min_ms(
         &mut self,
         millis: i64) {
         self.timeline.borrow_mut().set_min_duration(Duration::from_millis(millis as u64));
     }
 
-    pub fn with_min_secs(
+    pub(crate) fn with_min_secs(
         &mut self,
         secs: i64) {
         self.timeline.borrow_mut().set_min_duration(Duration::from_secs(secs as u64));
     }
 
-    pub fn apply(
+    pub(crate) fn apply(
         self,
         exporter: &mut UniversalExporterSwapper) -> Result<(), Box<EvalAltResult>> {
         match self.timeline.borrow_mut().apply(exporter) {
@@ -399,7 +399,7 @@ impl ScriptTimeline {
         }
     }
 
-    pub fn with_event_one(
+    pub(crate) fn with_event_one(
         &mut self,
         event: ScriptEvent,
         id_field: String,
@@ -410,7 +410,7 @@ impl ScriptTimeline {
         self.with_event(event, &fields, flags)
     }
 
-    pub fn with_event_two(
+    pub(crate) fn with_event_two(
         &mut self,
         event: ScriptEvent,
         id_field_one: String,
@@ -423,7 +423,7 @@ impl ScriptTimeline {
         self.with_event(event, &fields, flags)
     }
 
-    pub fn with_event_three(
+    pub(crate) fn with_event_three(
         &mut self,
         event: ScriptEvent,
         id_field_one: String,
@@ -438,7 +438,7 @@ impl ScriptTimeline {
         self.with_event(event, &fields, flags)
     }
 
-    pub fn with_event_four(
+    pub(crate) fn with_event_four(
         &mut self,
         event: ScriptEvent,
         id_field_one: String,

--- a/one_collect/src/perf_event/bpf.rs
+++ b/one_collect/src/perf_event/bpf.rs
@@ -36,7 +36,7 @@ struct bpf_element {
     flags: u64,
 }
 
-pub fn bpf_get_map_fd_by_path(
+pub(crate) fn bpf_get_map_fd_by_path(
     path: &std::ffi::CStr) -> IOResult<i32> {
     let mut obj = bpf_obj::default();
     obj.pathname = path.as_ptr() as u64;
@@ -53,7 +53,7 @@ pub fn bpf_get_map_fd_by_path(
     }
 }
 
-pub fn bpf_get_map_fd(
+pub(crate) fn bpf_get_map_fd(
     id: u32) -> IOResult<i32> {
     let mut get = bpf_get_id::default();
     get.start_id = id;
@@ -70,7 +70,7 @@ pub fn bpf_get_map_fd(
     }
 }
 
-pub fn bpf_set_map_element(
+pub(crate) fn bpf_set_map_element(
     fd: i32,
     key: u64,
     value: u64) -> IOResult<()> {

--- a/one_collect/src/perf_event/events.rs
+++ b/one_collect/src/perf_event/events.rs
@@ -3,7 +3,7 @@
 
 use super::{EventField, Event, LocationType};
 
-pub fn lost() -> Event {
+pub(crate) fn lost() -> Event {
     let mut event = Event::new(0, "__lost".into());
     let mut offset: usize = 0;
     let len: usize;
@@ -24,7 +24,7 @@ pub fn lost() -> Event {
     event
 }
 
-pub fn comm() -> Event {
+pub(crate) fn comm() -> Event {
     let mut event = Event::new(0, "__comm".into());
     let mut offset: usize = 0;
     let len: usize;
@@ -50,7 +50,7 @@ pub fn comm() -> Event {
     event
 }
 
-pub fn exit() -> Event {
+pub(crate) fn exit() -> Event {
     let mut event = Event::new(0, "__exit".into());
     let mut offset: usize = 0;
     let mut len: usize;
@@ -87,7 +87,7 @@ pub fn exit() -> Event {
     event
 }
 
-pub fn fork() -> Event {
+pub(crate) fn fork() -> Event {
     let mut event = Event::new(0, "__fork".into());
     let mut offset: usize = 0;
     let mut len: usize;
@@ -124,7 +124,7 @@ pub fn fork() -> Event {
     event
 }
 
-pub fn mmap() -> Event {
+pub(crate) fn mmap() -> Event {
     let mut event = Event::new(0, "__mmap".into());
     let mut offset: usize = 0;
     let mut len: usize;
@@ -199,7 +199,7 @@ pub fn mmap() -> Event {
     event
 }
 
-pub fn lost_samples() -> Event {
+pub(crate) fn lost_samples() -> Event {
     let mut event = Event::new(0, "__lost_samples".into());
     let offset: usize = 0;
     let len: usize;
@@ -215,7 +215,7 @@ pub fn lost_samples() -> Event {
     event
 }
 
-pub fn cswitch() -> Event {
+pub(crate) fn cswitch() -> Event {
     let mut event = Event::new(0, "__cswitch".into());
     let mut offset: usize = 0;
     let len: usize;

--- a/one_collect/src/perf_event/mod.rs
+++ b/one_collect/src/perf_event/mod.rs
@@ -35,12 +35,12 @@ pub(crate) struct CaptureEnvironmentOptions {
 }
 
 impl CaptureEnvironmentOptions {
-    pub fn with_all_mmaps(&mut self) -> &mut Self {
+    pub(crate) fn with_all_mmaps(&mut self) -> &mut Self {
         self.all_mmaps = true;
         self
     }
 
-    pub fn all_mmaps(&self) -> bool {
+    pub(crate) fn all_mmaps(&self) -> bool {
         self.all_mmaps
     }
 }
@@ -1299,7 +1299,7 @@ mod tests {
     }
 
     impl MockData {
-        pub fn new(
+        pub(crate) fn new(
             sample_type: u64,
             read_format: u64) -> Self {
             let mut attr = perf_event_attr::default();
@@ -1315,7 +1315,7 @@ mod tests {
             }
         }
 
-        pub fn push(
+        pub(crate) fn push(
             &mut self,
             slice: &[u8]) {
             let entry: (usize, usize) = (self.data.len(), slice.len());

--- a/one_collect/src/perf_event/rb/mod.rs
+++ b/one_collect/src/perf_event/rb/mod.rs
@@ -494,14 +494,14 @@ pub(crate) struct CommonRingBuf {
 }
 
 impl CommonRingBuf {
-    pub fn new(
+    pub(crate) fn new(
         attributes: perf_event_attr) -> Self {
         Self {
             attributes: Rc::new(attributes),
         }
     }
 
-    pub fn without_callstack(
+    pub(crate) fn without_callstack(
         self) -> Self {
         /* If no callchain/stack, then don't do anything */
         if !self.attributes.has_format(PERF_SAMPLE_CALLCHAIN) &&
@@ -524,7 +524,7 @@ impl CommonRingBuf {
         clone
     }
 
-    pub fn for_cpu(
+    pub(crate) fn for_cpu(
         &self,
         cpu: u32) -> CpuRingBuf {
         CpuRingBuf::new(
@@ -540,7 +540,7 @@ pub(crate) struct CpuRingCursor {
 }
 
 impl CpuRingCursor {
-    pub fn set(
+    pub(crate) fn set(
         &mut self,
         start: u64,
         end: u64) {
@@ -548,17 +548,17 @@ impl CpuRingCursor {
         self.end = end;
     }
 
-    pub fn advance(
+    pub(crate) fn advance(
         &mut self,
         len: u16) {
         self.start += len as u64;
     }
 
-    pub fn more(&self) -> bool {
+    pub(crate) fn more(&self) -> bool {
         self.start < self.end
     }
 
-    pub fn start(&self) -> u64 {
+    pub(crate) fn start(&self) -> u64 {
         self.start
     }
 }
@@ -573,7 +573,7 @@ pub(crate) struct CpuRingReader {
 }
 
 impl<'a> CpuRingReader {
-    pub fn new(
+    pub(crate) fn new(
         pages: *mut u8,
         pages_len: usize) -> Self {
         let slice = unsafe {
@@ -603,7 +603,7 @@ impl<'a> CpuRingReader {
         }
     }
 
-    pub fn new_unowned(
+    pub(crate) fn new_unowned(
         pages: *mut u8,
         pages_len: usize) -> Self {
         let mut reader = Self::new(pages, pages_len);
@@ -619,7 +619,7 @@ impl<'a> CpuRingReader {
         }
     }
 
-    pub fn begin_reading(
+    pub(crate) fn begin_reading(
         &self,
         cursor: &mut CpuRingCursor) {
         let head = self.head();
@@ -638,7 +638,7 @@ impl<'a> CpuRingReader {
         );
     }
 
-    pub fn data_slice(
+    pub(crate) fn data_slice(
         &'a self) -> &'a [u8] {
         let slice = self.slice();
         let data_start = self.data_offset as usize;
@@ -646,7 +646,7 @@ impl<'a> CpuRingReader {
         &slice[data_start..data_end]
     }
 
-    pub fn peek_header(
+    pub(crate) fn peek_header(
         &'a self,
         cursor: &CpuRingCursor,
         data_slice: &'a [u8],
@@ -667,7 +667,7 @@ impl<'a> CpuRingReader {
         }
     }
 
-    pub fn peek_u64(
+    pub(crate) fn peek_u64(
         &self,
         cursor: &CpuRingCursor,
         offset: u64) -> u64 {
@@ -678,7 +678,7 @@ impl<'a> CpuRingReader {
         u64::from_ne_bytes(data_slice[start..end].try_into().unwrap())
     }
 
-    pub fn read(
+    pub(crate) fn read(
         &'a self,
         cursor: &mut CpuRingCursor,
         temp: &'a mut Vec<u8>) -> IOResult<&'a [u8]> {
@@ -717,7 +717,7 @@ impl<'a> CpuRingReader {
         }
     }
 
-    pub fn end_reading(
+    pub(crate) fn end_reading(
         &mut self,
         cursor: &CpuRingCursor) {
         trace!("end_reading: updating tail to {:#x}", cursor.start());
@@ -760,7 +760,7 @@ pub(crate) struct CpuRingBuf {
 }
 
 impl CpuRingBuf {
-    pub fn new(
+    pub(crate) fn new(
         cpu: u32,
         attributes: Rc<perf_event_attr>) -> Self {
         let mut sample_time_offset = abi::Header::data_offset() as u16;
@@ -791,7 +791,7 @@ impl CpuRingBuf {
         }
     }
 
-    pub fn ancillary(&self) -> AncillaryData {
+    pub(crate) fn ancillary(&self) -> AncillaryData {
         AncillaryData {
             cpu: self.cpu,
             attributes: self.attributes.clone(),
@@ -827,19 +827,19 @@ impl CpuRingBuf {
         }
     }
 
-    pub fn sample_time_offset(&self) -> u16 {
+    pub(crate) fn sample_time_offset(&self) -> u16 {
         self.sample_time_offset
     }
 
-    pub fn id(&self) -> Option<u64> {
+    pub(crate) fn id(&self) -> Option<u64> {
         self.id
     }
 
-    pub fn is_open(&self) -> bool {
+    pub(crate) fn is_open(&self) -> bool {
         self.fd.is_some()
     }
 
-    pub fn open(
+    pub(crate) fn open(
         &mut self,
         target_pid: Option<i32>) -> IOResult<()> {
         let pid = target_pid.unwrap_or(-1);
@@ -862,7 +862,7 @@ impl CpuRingBuf {
         Ok(())
     }
 
-    pub fn create_reader(
+    pub(crate) fn create_reader(
         &self,
         page_count: usize) -> IOResult<CpuRingReader> {
         if self.fd.is_none() {
@@ -905,7 +905,7 @@ impl CpuRingBuf {
         }
     }
 
-    pub fn enable(
+    pub(crate) fn enable(
         &self) -> IOResult<()> {
         if self.fd.is_none() {
             warn!("enable failed: ring buffer not open, cpu={}", self.cpu);
@@ -930,7 +930,7 @@ impl CpuRingBuf {
         Ok(())
     }
 
-    pub fn disable(
+    pub(crate) fn disable(
         &self) -> IOResult<()> {
         if self.fd.is_none() {
             warn!("disable failed: ring buffer not open, cpu={}", self.cpu);
@@ -955,7 +955,7 @@ impl CpuRingBuf {
         Ok(())
     }
 
-    pub fn redirect_to(
+    pub(crate) fn redirect_to(
         &self, 
         target: &Self) -> IOResult<()> {
         if self.fd.is_none() || target.fd.is_none() {
@@ -991,7 +991,7 @@ impl CpuRingBuf {
         }
     }
 
-    pub fn set_filter(&self, filter: &std::ffi::CStr) -> IOResult<()> {
+    pub(crate) fn set_filter(&self, filter: &std::ffi::CStr) -> IOResult<()> {
         if self.fd.is_none() {
             warn!("set_filter failed: ring buffer not open, cpu={}", self.cpu);
             return Err(io_error("Ring buffer is not open."));
@@ -1070,7 +1070,7 @@ unsafe impl Send for InProcessRingBufWriter {}
 impl InProcessRingBuf {
     /// Create a new in-process ring buffer with the given number of data pages.
     /// The data_pages value will be rounded up to the next power of two.
-    pub fn new(data_pages: usize) -> Self {
+    pub(crate) fn new(data_pages: usize) -> Self {
         let page_size = unsafe { sysconf(_SC_PAGE_SIZE) as usize };
         let data_pages = data_pages.next_power_of_two();
         let data_size = data_pages * page_size;
@@ -1103,7 +1103,7 @@ impl InProcessRingBuf {
 
     /// Create a `CpuRingReader` that reads from this buffer's memory.
     /// The reader does NOT own the memory.
-    pub fn create_reader(&mut self) -> CpuRingReader {
+    pub(crate) fn create_reader(&mut self) -> CpuRingReader {
         CpuRingReader::new_unowned(
             self.data.as_mut_ptr(),
             self.data.len())
@@ -1116,7 +1116,7 @@ impl InProcessRingBuf {
     /// The returned `InProcessRingBufWriter` holds a raw pointer into
     /// `self.data`. The caller must ensure that `self` outlives both the
     /// writer and the reader.
-    pub fn writer(&mut self) -> InProcessRingBufWriter {
+    pub(crate) fn writer(&mut self) -> InProcessRingBufWriter {
         InProcessRingBufWriter {
             data: self.data.as_mut_ptr(),
             data_offset: self.data_offset,

--- a/one_collect/src/perf_event/rb/source.rs
+++ b/one_collect/src/perf_event/rb/source.rs
@@ -14,7 +14,7 @@ struct RingBufSessionHook {
 }
 
 impl RingBufSessionHook {
-    pub fn new(
+    pub(crate) fn new(
         builder_hook: impl FnOnce(&mut RingBufSessionBuilder) + 'static,
         session_hook: impl FnOnce(&mut PerfSession) + 'static) -> Self {
         Self {
@@ -23,11 +23,11 @@ impl RingBufSessionHook {
         }
     }
 
-    pub fn builder_hook(&mut self) -> Option<BoxedBuilderHook> {
+    pub(crate) fn builder_hook(&mut self) -> Option<BoxedBuilderHook> {
         self.builder_hook.take()
     }
 
-    pub fn session_hook(&mut self) -> Option<BoxedSessionHook> {
+    pub(crate) fn session_hook(&mut self) -> Option<BoxedSessionHook> {
         self.session_hook.take()
     }
 }

--- a/one_collect/src/scripting/os/linux.rs
+++ b/one_collect/src/scripting/os/linux.rs
@@ -31,7 +31,7 @@ pub(crate) fn version() -> (u16, u16) {
     (major, minor)
 }
 
-pub struct OSScriptEngine {
+pub(crate) struct OSScriptEngine {
     probe_cleanups: Writable<Vec<String>>,
 }
 
@@ -127,7 +127,7 @@ impl OSScriptEngine {
         }
     }
 
-    pub fn enable(
+    pub(crate) fn enable(
         &mut self,
         engine: &mut Engine) {
         /* Use single tracefs for all function invocations */
@@ -343,7 +343,7 @@ impl OSScriptEngine {
         info!("OSScriptEngine::enable: Linux script functions registered successfully");
     }
 
-    pub fn cleanup_task(&mut self) -> Box<dyn FnMut()> {
+    pub(crate) fn cleanup_task(&mut self) -> Box<dyn FnMut()> {
         let probe_cleanups = self.probe_cleanups.clone();
 
         Box::new(move || {

--- a/one_collect/src/scripting/os/mod.rs
+++ b/one_collect/src/scripting/os/mod.rs
@@ -10,7 +10,7 @@ pub use windows::*;
 
 /* Linux */
 #[cfg(any(doc, target_os = "linux"))]
-pub mod linux;
+pub(crate) mod linux;
 
 #[cfg(target_os = "linux")]
-pub use linux::*;
+pub(crate) use linux::*;

--- a/one_collect/src/scripting/os/mod.rs
+++ b/one_collect/src/scripting/os/mod.rs
@@ -3,10 +3,10 @@
 
 /* Windows */
 #[cfg(any(doc, target_os = "windows"))]
-pub mod windows;
+pub(super) mod windows;
 
 #[cfg(target_os = "windows")]
-pub use windows::*;
+pub(super) use windows::*;
 
 /* Linux */
 #[cfg(any(doc, target_os = "linux"))]

--- a/one_collect/src/scripting/os/windows.rs
+++ b/one_collect/src/scripting/os/windows.rs
@@ -54,7 +54,7 @@ pub(crate) fn version() -> (u16, u16) {
 }
 
 #[derive(Default)]
-pub struct OSScriptEngine {
+pub(crate) struct OSScriptEngine {
 }
 
 impl OSScriptEngine {
@@ -109,7 +109,7 @@ impl OSScriptEngine {
         Ok(event)
     }
 
-    pub fn enable(
+    pub(crate) fn enable(
         &mut self,
         engine: &mut Engine) {
         engine.register_fn(
@@ -154,7 +154,7 @@ impl OSScriptEngine {
         });
     }
 
-    pub fn cleanup_task(&mut self) -> Box<dyn FnMut()> {
+    pub(crate) fn cleanup_task(&mut self) -> Box<dyn FnMut()> {
         /* Nothing */
         Box::new(|| {})
     }

--- a/record-trace/Cargo.toml
+++ b/record-trace/Cargo.toml
@@ -12,6 +12,9 @@ engine = { path = "engine" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[lints.rust]
+unreachable_pub = "deny"
+
 [lints.clippy]
 absurd_extreme_comparisons = "deny"
 almost_swapped = "deny"

--- a/record-trace/engine/Cargo.toml
+++ b/record-trace/engine/Cargo.toml
@@ -13,6 +13,9 @@ one_collect = { path = "../../one_collect" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[lints.rust]
+unreachable_pub = "deny"
+
 [lints.clippy]
 absurd_extreme_comparisons = "deny"
 almost_swapped = "deny"

--- a/record-trace/engine/src/export.rs
+++ b/record-trace/engine/src/export.rs
@@ -63,7 +63,7 @@ pub (crate) struct PerfViewExporter {
 }
 
 impl PerfViewExporter {
-    pub fn new() -> Self {
+    pub (crate) fn new() -> Self {
         Self {
         }
     }
@@ -248,7 +248,7 @@ pub (crate) struct NetTraceExporter {
 }
 
 impl NetTraceExporter {
-    pub fn new() -> Self {
+    pub (crate) fn new() -> Self {
         Self {
             output_path: PathBuf::new(),
         }

--- a/record-trace/ffi/Cargo.toml
+++ b/record-trace/ffi/Cargo.toml
@@ -16,6 +16,9 @@ lto = true
 engine = { path = "../engine" }
 tracing = "0.1"
 
+[lints.rust]
+unreachable_pub = "deny"
+
 [lints.clippy]
 absurd_extreme_comparisons = "deny"
 almost_swapped = "deny"

--- a/ruwind/Cargo.toml
+++ b/ruwind/Cargo.toml
@@ -12,6 +12,9 @@ rustc-demangle = "0.1"
 libc = "0.2"
 tracing = "0.1"
 
+[lints.rust]
+unreachable_pub = "deny"
+
 [lints.clippy]
 absurd_extreme_comparisons = "deny"
 almost_swapped = "deny"

--- a/ruwind/src/x64unwinder.rs
+++ b/ruwind/src/x64unwinder.rs
@@ -86,7 +86,7 @@ impl FrameOffsets {
 }
 
 #[derive(Default)]
-pub struct Unwinder {
+pub(crate) struct Unwinder {
     frame_cache: HashMap<ModuleKey, FrameOffsets>,
     frame_table: FrameHeaderTable,
     registers: Vec<u64>,
@@ -96,7 +96,7 @@ pub struct Unwinder {
 }
 
 impl Unwinder {
-    pub fn new() -> Self { Self::default() }
+    pub(crate) fn new() -> Self { Self::default() }
 
     fn stack_value(
         rsp: u64,


### PR DESCRIPTION
## Summary

Converts 134 items from `pub` to `pub(crate)` across `one_collect` (132) and `ruwind` (2), as flagged by rustc's `unreachable_pub` lint. No behavior changes, no public API changes.

## Motivation

In Rust, `pub` means "visible in the parent module's scope," not "visible to the world." When `pub fn foo()` lives in a `mod bar;` (private module), the `pub` is misleading. `foo` is unreachable from outside the crate regardless. The honest spelling is `pub(crate)`.

The candidates were generated mechanically with:

```bash
cargo clippy --lib -- -W unreachable_pub -A clippy::all
```

Tightening these has three benefits:

1. **Accurate intent at the call site.** A reader seeing `pub fn` reasonably assumes it's part of the published API. `pub(crate) fn` says exactly what it is.
2. **Honest visibility in tooling.** API-surface analyzers (`cargo public-api`, semver checkers, `rustdoc --document-private-items`) and IDE summaries treat `pub` and `pub(crate)` distinctly. After this change they reflect the true external surface.
3. **Refactoring safety.** If `mod bar;` were ever changed to `pub mod bar;`, all the `pub` items inside would silently become external API. `pub(crate)` prevents that accidental expansion.