### PR TITLE
Optimize symbol resolution

### DIFF
--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -1388,10 +1388,13 @@ impl ExportMachineOSHooks for ExportMachine {
         kernel_symbols: &mut impl ExportSymbolReader) {
 
         // Cached kernel symbol for in-memory matching.
+        // name_id is interned once in Phase 2 so Phase 3 does not pay the
+        // hash + bucket-walk + memcmp cost of strings.to_id for every
+        // (process, symbol) pair.
         struct CachedKernelSymbol {
             start: u64,
             end: u64,
-            name: String,
+            name_id: usize,
         }
 
         let mut frames = Vec::new();
@@ -1433,10 +1436,11 @@ impl ExportMachineOSHooks for ExportMachine {
             };
 
             if has_match {
+                let name_id = self.strings.to_id(kernel_symbols.name());
                 matched_symbols.push(CachedKernelSymbol {
                     start,
                     end,
-                    name: kernel_symbols.name().to_string(),
+                    name_id,
                 });
             }
         }
@@ -1483,11 +1487,12 @@ impl ExportMachineOSHooks for ExportMachine {
                     seen[idx] = true;
                     added += 1;
 
-                    let name_id = self.strings.to_id(&sym.name);
-                    let symbol = ExportSymbol::new(name_id, sym.start, sym.end);
+                    let symbol = ExportSymbol::new(sym.name_id, sym.start, sym.end);
 
                     trace!("Adding symbol to mapping: mapping_id={}, name={}, start={:#x}, end={:#x}",
-                        kernel.id(), &sym.name, sym.start, sym.end);
+                        kernel.id(),
+                        self.strings.from_id(sym.name_id).unwrap_or(""),
+                        sym.start, sym.end);
                     kernel.add_symbol(symbol);
                 }
             }


### PR DESCRIPTION
## Summary

Hoists `InternedStrings::to_id` for kernel symbol names from the per-process loop (Phase 3) into the per-symbol caching step (Phase 2) of `os_add_kernel_mappings_with`. The cache now stores a `usize` id instead of a `String`, avoiding redundant hash-map lookups and per-symbol heap allocations. On the existing `kallsyms` benchmark this is a ~31-37% wall-clock improvement.

## Motivation

`os_add_kernel_mappings_with` runs at the end of every recording session as part of `capture_and_resolve_symbols`. Phase 1 collects unique kernel IPs across all processes, Phase 2 walks `/proc/kallsyms` keeping only symbols whose ranges contain at least one observed IP, and Phase 3 attaches the matching symbols to each process's kernel mapping.

Previously Phase 3 called `self.strings.to_id(&sym.name)` for every `(process, matched symbol)` pair, even though the resulting id is a pure function of the symbol name. Each call goes through the interner's hash map: it hashes the full name with `XxHash64`, walks the bucket, and does a slice memcmp on hit. In whole-system traces where many processes share the same hot kernel functions, the same id is recomputed dozens to hundreds of times.

Phase 2 also called `kernel_symbols.name().to_string()` for every matched symbol, producing one heap allocation per entry.

### Why this is faster

Each `to_id` call in Phase 3 is a full interner hash-map lookup. By doing that lookup once per matched symbol in Phase 2 instead of once per `(process, matched symbol)` pair in Phase 3, we eliminate all the redundant hashing and bucket walks. The id is then read directly out of the cached struct.

### Why this uses less memory

- The previous `name: String` field held a heap-allocated copy of the symbol name per cached entry. The interner already stores the canonical copy, so this was effectively a duplicate. Replacing it with the interner's `usize` id removes one heap allocation per matched symbol.
- `CachedKernelSymbol` shrinks from `{u64, u64, String}` (40 bytes plus heap) to `{u64, u64, usize}` (24 bytes), so the cache itself takes less memory and packs more entries per cache line, which helps Phase 3's per-IP `binary_search_by_key`.

## Benchmarks

Bench: `one_collect/benches/kallsyms.rs`, group `kallsyms/resolve 100p x 200000sym`. 100 processes, 200 000 mock kallsyms entries, 500 kernel IPs per process.

Baseline (`main`):

```text
kallsyms/resolve 100p x 200000sym
                        time:   [52.749 ms 54.550 ms 56.425 ms]
```

With fix:

```text
kallsyms/resolve 100p x 200000sym
                        time:   [34.572 ms 35.075 ms 35.791 ms]
                        change: [-36.941% -34.246% -31.702%] (p = 0.00 < 0.05)
                        Performance has improved.
```