### PR TITLE
Replace  panics in dynamic location handling with safe  fallback

### DIFF
--- a/one_collect/src/event/mod.rs
+++ b/one_collect/src/event/mod.rs
@@ -588,12 +588,13 @@ impl EventFormat {
                 &slice[2..2+bytes]
             },
 
-            LocationType::DynRelative => {
-                todo!("Need to support relative location");
-            },
-
-            LocationType::DynAbsolute => {
-                todo!("Need to support absolute location");
+            LocationType::DynRelative | LocationType::DynAbsolute => {
+                /* TODO: Dynamic locations require a relative/absolute
+                 * resolver and are not yet supported through the
+                 * direct-offset path. Return EMPTY rather than panicking
+                 * until resolution is wired through (Linux tracefs
+                 * `__rel_loc` / `__dyn_loc`). */
+                EMPTY
             },
         }
     }


### PR DESCRIPTION
## Summary

`EventFormat::get_data_with_offset_direct` had two `todo!()` arms for `LocationType::DynRelative` and `LocationType::DynAbsolute` that panic the process if hit. This change replaces them with a single combined arm that returns `EMPTY`, matching the behavior of every other failure path in the same function.

## Motivation

These variants are produced by Linux `tracefs` (parsing `__rel_loc` / `__dyn_loc` markers) and by the cross-platform `ScriptEvent::append_field` helper. Whether any current caller actually feeds such a field into `get_data_with_offset_direct` is not obvious from a single review pass. For example: https://github.com/open-telemetry/otel-arrow/pull/3187#discussion_r3382773864

A `todo!()` here forces reviewer to either:

- ask for defensive scaffolding (`catch_unwind`, etc.) around callers, or
- chase the call graph to prove the branch is unreachable.

Both are wasted effort for a function whose every other failure mode already returns `EMPTY`. `todo!()` is a "not implemented yet" marker; using it in shipped code as a stand-in for "shouldn't happen" promotes a missing feature to a potential process-killing panic and adds review friction.