### PR TITLE
Make one_collect publish-ready for crates.io

### DIFF
--- a/one_collect/Cargo.toml
+++ b/one_collect/Cargo.toml
@@ -5,6 +5,20 @@ version = "0.0.0-dev"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/microsoft/one-collect"
+homepage = "https://github.com/microsoft/one-collect"
+documentation = "https://docs.rs/one_collect"
+readme = "README.md"
+keywords = ["profiling", "perf_events", "etw", "tracing", "observability"]
+categories = [
+    "development-tools::profiling",
+    "development-tools::debugging",
+    "os::linux-apis",
+    "os::windows-apis",
+]
+exclude = [
+    "UnitTest.pprof",
+    "test_assets/stack_gen/**",
+]
 
 [features]
 default = ["scripting"]

--- a/one_collect/LICENSE
+++ b/one_collect/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/one_collect/README.md
+++ b/one_collect/README.md
@@ -1,0 +1,50 @@
+# one_collect
+
+An extremely fast, composable Rust framework for collecting event and profiling
+data on Linux and Windows.
+
+`one_collect` makes collecting, analyzing, and exporting events and profiles easy
+and efficient. It is highly composable, allowing you to tweak all aspects of how
+events and profiles are collected and processed.
+
+- On **Linux**, the main source of events and profiling is the perf events
+  facility.
+- On **Windows**, the main source of events is the ETW facility.
+
+Individual events can be hooked and processed as they arrive, or entire sessions
+of events and profiling data can be managed for you. Regardless of the source,
+data flows through a pipeline that invokes closures as it arrives. This allows
+both pre-built scenarios and custom in-process scenarios to use the same
+pipelines. Collected data can be exported to several pre-built or custom formats.
+
+## Stack unwinding
+
+On x64 Linux, the framework supports callstack unwinding using live DWARF
+decoding. The unwinder also understands anonymous code sections, such as those
+from C# and Java, and will unwind through them by scanning for x64 calling
+conventions. This allows unwinding not only native ELF files, but also JIT'd code
+without per-language support. The unwinding implementation lives in the internal
+`ruwind` module; the types it surfaces in the public API are re-exported from
+the `one_collect::unwind` module.
+
+## Pre-release software
+
+This project is currently in pre-release mode. It is expected that there may be
+breaking API and behavioral changes. We expect this to stabilize before a
+version 1.0 release.
+
+## Features
+
+- `scripting` *(default)* — enables the Rhai-based scripting support.
+
+## License
+
+Licensed under the [MIT](https://github.com/microsoft/one-collect/blob/main/LICENSE)
+license.
+
+## Contributing
+
+See the repository's
+[CONTRIBUTING](https://github.com/microsoft/one-collect/blob/main/CONTRIBUTING.md)
+guide. This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/one_collect/src/lib.rs
+++ b/one_collect/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+#![doc = include_str!("../README.md")]
+
 use std::hash::{Hash, Hasher};
 
 #[repr(C)]

--- a/one_collect/src/procfs.rs
+++ b/one_collect/src/procfs.rs
@@ -13,7 +13,7 @@ use crate::PathBufInteger;
 ///
 /// # Arguments
 ///
-/// * `path` - A mutable reference to a PathBuf pointing to the procfs directory of a process (e.g. /proc/[pid]).
+/// * `path` - A mutable reference to a PathBuf pointing to the procfs directory of a process (e.g. `/proc/[pid]`).
 ///
 /// # Returns
 ///


### PR DESCRIPTION
## Summary

Adds the metadata crates.io needs to publish `one_collect`, a crate-level README
that doubles as the docs.rs landing page, and a crate-local license file.

## What changed

- Add `keywords`, `categories`, `homepage`, `documentation`, and `readme`
  fields to `Cargo.toml`.
- Add a crate-level `README.md` and surface it as the docs.rs landing page via
  `#![doc = include_str!("../README.md")]`.
- Add a crate-local `LICENSE` (copy of the repo-root MIT license) so it is
  included in the published `.crate` (cargo only packages files under the crate
  directory).
- `exclude` the `UnitTest.pprof` test artifact and the `stack_gen` C helper from
  the published package.
- Fix a `rustdoc` warning in `procfs.rs` (`/proc/[pid]` was parsed as an
  intra-doc link) so the docs.rs build is warning-free.

## Notes

- The crate version is left at `0.0.0-dev`; the official release pipeline
  replaces it with a real version at publish time.
