### PR TITLE
Record-Trace: Enable duration and memory limits

### DIFF
--- a/record-trace/Cargo.lock
+++ b/record-trace/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "one_collect",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/record-trace/engine/Cargo.lock
+++ b/record-trace/engine/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "one_collect",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/record-trace/engine/Cargo.toml
+++ b/record-trace/engine/Cargo.toml
@@ -13,6 +13,9 @@ one_collect = { path = "../../one_collect" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_ProcessStatus", "Win32_System_Threading"] }
+
 [lints.rust]
 unreachable_pub = "deny"
 

--- a/record-trace/engine/src/commandline.rs
+++ b/record-trace/engine/src/commandline.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use std::path::PathBuf;
 use std::ffi::OsString;
 use std::process;
+use std::time::Duration;
 
 use crate::export::{Exporter, NetTraceExporter, PerfViewExporter};
 
@@ -35,6 +36,12 @@ struct Args {
 
     #[arg(long, help = "Display samples live")]
     live: bool,
+
+    #[arg(long, help = "Stop collecting after the specified number of seconds")]
+    duration: Option<u64>,
+
+    #[arg(long, help = "Stop collecting once this process uses the specified amount of memory, in megabytes")]
+    max_memory: Option<u64>,
 
     #[arg(long = "pid", help = "Capture data for the specified process ID.  Multiple pids can be specified, one per usage of --pid")]
     target_pids: Option<Vec<i32>>,
@@ -99,6 +106,8 @@ pub struct RecordArgs {
     soft_page_faults: bool,
     hard_page_faults: bool,
     live: bool,
+    duration: Option<Duration>,
+    max_memory_bytes: Option<u64>,
     target_pids: Option<Vec<i32>>,
     target_cpus: Option<Vec<u16>>,
     script: Option<String>,
@@ -155,6 +164,8 @@ impl RecordArgs {
             soft_page_faults: command_args.soft_page_faults,
             hard_page_faults: command_args.hard_page_faults,
             live: command_args.live,
+            duration: command_args.duration.map(Duration::from_secs),
+            max_memory_bytes: command_args.max_memory.map(|mb| mb.saturating_mul(1024 * 1024)),
             target_pids: command_args.target_pids,
             target_cpus: command_args.target_cpus,
             script,
@@ -206,6 +217,14 @@ impl RecordArgs {
         self.live
     }
 
+    pub (crate) fn duration(&self) -> Option<Duration> {
+        self.duration
+    }
+
+    pub (crate) fn max_memory_bytes(&self) -> Option<u64> {
+        self.max_memory_bytes
+    }
+
     pub (crate) fn target_pids(&self) -> &Option<Vec<i32>> {
         &self.target_pids
     }
@@ -238,6 +257,12 @@ impl RecordArgs {
         info!("Arguments parsed: soft_page_faults={}", self.soft_page_faults);
         info!("Arguments parsed: hard_page_faults={}", self.hard_page_faults);
         info!("Arguments parsed: live={}", self.live);
+        if let Some(duration) = self.duration {
+            info!("Arguments parsed: duration_secs={}", duration.as_secs());
+        }
+        if let Some(max_memory_bytes) = self.max_memory_bytes {
+            info!("Arguments parsed: max_memory_bytes={}", max_memory_bytes);
+        }
         if let Some(ref pids) = self.target_pids {
             info!("Arguments parsed: target_pids={:?}", pids);
         }

--- a/record-trace/engine/src/recorder.rs
+++ b/record-trace/engine/src/recorder.rs
@@ -25,6 +25,49 @@ use std::fmt::Write;
 
 const DEFAULT_CPU_FREQUENCY: u64 = 1000;
 
+/// Returns the current process's resident memory usage in bytes, or `None`
+/// if it cannot be determined on this platform.
+#[cfg(target_os = "windows")]
+fn current_process_memory_bytes() -> Option<u64> {
+    use windows_sys::Win32::System::ProcessStatus::{
+        GetProcessMemoryInfo,
+        PROCESS_MEMORY_COUNTERS,
+    };
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    // SAFETY: We pass a zeroed, correctly-sized PROCESS_MEMORY_COUNTERS and the
+    // size of that structure. GetProcessMemoryInfo fills it in and the pseudo
+    // handle from GetCurrentProcess is always valid for the current process.
+    unsafe {
+        let mut counters: PROCESS_MEMORY_COUNTERS = std::mem::zeroed();
+        let size = std::mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32;
+        if GetProcessMemoryInfo(GetCurrentProcess(), &mut counters, size) != 0 {
+            Some(counters.WorkingSetSize as u64)
+        } else {
+            None
+        }
+    }
+}
+
+/// Returns the current process's resident memory usage in bytes, or `None`
+/// if it cannot be determined on this platform.
+#[cfg(target_os = "linux")]
+fn current_process_memory_bytes() -> Option<u64> {
+    // /proc/self/statm reports the resident set size as a count of pages in
+    // its second field.
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let rss_pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+
+    Some(rss_pages.saturating_mul(one_collect::os::system_page_size()))
+}
+
+/// Returns the current process's resident memory usage in bytes, or `None`
+/// if it cannot be determined on this platform.
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+fn current_process_memory_bytes() -> Option<u64> {
+    None
+}
+
 pub struct Recorder {
     args: RecordArgs,
     output: Arc<EngineOutput>,
@@ -267,6 +310,46 @@ impl Recorder {
         let print_banner = Arc::new(AtomicBool::new(true));
         let parse_output = self.output.clone();
 
+        // Stop conditions configured via the command line.
+        // The duration clock starts now, immediately before recording begins.
+        let deadline = self.args.duration()
+            .map(|duration| std::time::Instant::now() + duration);
+
+        // Querying process memory can be slow, so poll it on a dedicated
+        // background thread rather than inside the hot parse_until closure.
+        // The thread flips continue_recording once the limit is exceeded.
+        let memory_monitor = match self.args.max_memory_bytes() {
+            Some(max_memory_bytes) if current_process_memory_bytes().is_some() => {
+                let monitor_output = self.output.clone();
+                let monitor_continue = continue_recording.clone();
+                Some(std::thread::spawn(move || {
+                    const POLL_INTERVAL: std::time::Duration =
+                        std::time::Duration::from_millis(250);
+
+                    while monitor_continue.load(Ordering::SeqCst) {
+                        if let Some(used) = current_process_memory_bytes() {
+                            if used >= max_memory_bytes {
+                                info!(
+                                    "Stopping recording: memory limit reached: used_bytes={} limit_bytes={}",
+                                    used, max_memory_bytes);
+                                monitor_output.normal("Memory limit reached.");
+                                monitor_continue.store(false, Ordering::SeqCst);
+                                break;
+                            }
+                        }
+
+                        std::thread::sleep(POLL_INTERVAL);
+                    }
+                }))
+            },
+            Some(_) => {
+                self.output.error(
+                    "Warning: --max-memory is not supported on this platform and will be ignored.");
+                None
+            },
+            None => None,
+        };
+
         let parse_result = universal.parse_until("record-trace", move || {
             // Print the banner telling the user that recording has started.
             if print_banner.load(Ordering::SeqCst) {
@@ -280,9 +363,26 @@ impl Recorder {
                 continue_recording.store(false, Ordering::SeqCst);
             }
 
+            // Stop once the configured duration has elapsed.
+            if let Some(deadline) = deadline {
+                if std::time::Instant::now() >= deadline {
+                    info!("Stopping recording: duration limit reached");
+                    parse_output.normal("Duration limit reached.");
+                    continue_recording.store(false, Ordering::SeqCst);
+                }
+            }
+
             // When a callback returns non-zero, this will flip.
+            // The memory monitor thread (if any) also flips this when the
+            // configured memory limit is exceeded.
             !continue_recording.load(Ordering::SeqCst)
         });
+
+        // Recording has stopped; continue_recording is now false, so the
+        // memory monitor thread (if any) will observe it and exit.
+        if let Some(memory_monitor) = memory_monitor {
+            let _ = memory_monitor.join();
+        }
 
         let exporter = match parse_result {
             Ok(exporter) => {

--- a/record-trace/ffi/Cargo.lock
+++ b/record-trace/ffi/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "one_collect",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
We have scenarios where record-trace should automatically stop as if a user hit control-c when either a duration or memory limit is hit.

Add --duration and --max-memory arguments to allow these scenarios.

Honor duration within the parse_until callback directly.

Spawn a thread for memory monitoring, using OS specific functions. This ensures that memory monitoring does not affect the consumer threads ability to keep up with data rates.

Tested on both Windows and Linux manually for both --duration and --max-memory arguments, ensuring they stopped the trace at the correct points.