### PR TITLE
Fix ETW session GUID collision

### DIFF
--- a/one_collect/src/etw/abi.rs
+++ b/one_collect/src/etw/abi.rs
@@ -201,16 +201,50 @@ struct WNODE_HEADER {
     pub Flags: u32,
 }
 
-impl Default for WNODE_HEADER {
-    fn default() -> Self {
+impl WNODE_HEADER {
+    /// Namespace for deriving an ETW session's `Wnode.Guid` from its session
+    /// name. Must be a fixed byte string, distinct from the `EventSource`
+    /// provider-name namespace used by
+    /// `helpers::dotnet::scripting::guid_from_provider` so session-name and
+    /// provider-name GUIDs never collide.
+    ///
+    /// Any change to this string changes every derived GUID. That only affects
+    /// GUID identity, not crash recovery, which is name-based (see
+    /// [`TraceSession::start`]).
+    const SESSION_NAMESPACE: &[u8] = b"one_collect ETW session namespace";
+
+    /// Construct a `WNODE_HEADER` for a named ETW session destined for
+    /// `StartTraceW`. `Guid` is derived from `session_name` and
+    /// `WNODE_FLAG_TRACED_GUID` is set, so the kernel enforces per-name
+    /// uniqueness while sessions with distinct names coexist. Because the same
+    /// name always maps to the same GUID, the by-name `ControlTraceW(STOP)` in
+    /// `TraceSession::start` can reclaim a stale session across processes.
+    fn new(session_name: &str) -> Self {
         Self {
             BufferSize: std::mem::size_of::<EVENT_TRACE_PROPERTIES>() as u32,
             ProviderId: 0,
             HistoricalContext: 0,
             TimeStamp: 0,
-            Guid: Guid::from_u128(0x123),
+            Guid: Guid::v5_from_name(
+                Self::SESSION_NAMESPACE,
+                session_name.as_bytes()),
             ClientContext: 1,
             Flags: WNODE_FLAG_TRACED_GUID,
+        }
+    }
+
+    /// Construct a `WNODE_HEADER` for driving `ControlTraceW` by handle
+    /// (e.g. `flush_trace`, `TraceSession::remote_stop`) where `Wnode.Guid`
+    /// is ignored. The GUID is zero and `WNODE_FLAG_TRACED_GUID` is unset.
+    fn for_control() -> Self {
+        Self {
+            BufferSize: std::mem::size_of::<EVENT_TRACE_PROPERTIES>() as u32,
+            ProviderId: 0,
+            HistoricalContext: 0,
+            TimeStamp: 0,
+            Guid: Guid::from_u128(0),
+            ClientContext: 1,
+            Flags: 0,
         }
     }
 }
@@ -391,12 +425,24 @@ struct EVENT_TRACE_PROPERTIES {
     pub LoggerName: [u8; 1024],
 }
 
-impl Default for EVENT_TRACE_PROPERTIES {
-    fn default() -> Self {
+impl EVENT_TRACE_PROPERTIES {
+    /// Construct properties for a named ETW session to be started with
+    /// `StartTraceW`; see [`WNODE_HEADER::new`].
+    fn new(session_name: &str) -> Self {
+        Self::with_wnode(WNODE_HEADER::new(session_name))
+    }
+
+    /// Construct properties for driving `ControlTraceW` by handle;
+    /// see [`WNODE_HEADER::for_control`].
+    fn for_control() -> Self {
+        Self::with_wnode(WNODE_HEADER::for_control())
+    }
+
+    fn with_wnode(wnode: WNODE_HEADER) -> Self {
         let cpus = unsafe { GetActiveProcessorCount(0xFFFF) };
 
         Self {
-            Wnode: WNODE_HEADER::default(),
+            Wnode: wnode,
             BufferSize: 64,
             MinimumBuffers: cpus * 4,
             MaximumBuffers: cpus * 32,
@@ -827,7 +873,7 @@ impl TraceEnable {
 }
 
 pub(crate) fn flush_trace(handle: u64) {
-    let mut properties = EVENT_TRACE_PROPERTIES::default();
+    let mut properties = EVENT_TRACE_PROPERTIES::for_control();
 
     unsafe {
         ControlTraceW(
@@ -865,15 +911,15 @@ impl TraceSession {
     pub(super) fn new(
         name: String,
         buf_size_kb: u32) -> Self {
-        let mut session = Self {
-            properties: EVENT_TRACE_PROPERTIES::default(),
+        let mut properties = EVENT_TRACE_PROPERTIES::new(&name);
+
+        properties.BufferSize = buf_size_kb;
+
+        Self {
+            properties,
             name,
             handle: 0,
-        };
-
-        session.properties.BufferSize = buf_size_kb;
-
-        session
+        }
     }
 
     pub(super) fn handle(&self) -> u64 { self.handle }
@@ -983,7 +1029,7 @@ impl TraceSession {
 
     pub(super) fn remote_stop(
         handle: u64) {
-        let mut properties = EVENT_TRACE_PROPERTIES::default();
+        let mut properties = EVENT_TRACE_PROPERTIES::for_control();
 
         unsafe {
             ControlTraceW(

--- a/one_collect/src/helpers/dotnet/scripting/mod.rs
+++ b/one_collect/src/helpers/dotnet/scripting/mod.rs
@@ -12,8 +12,6 @@ use crate::scripting::ScriptEvent;
 use crate::Writable;
 use crate::Guid;
 
-use sha1::{Sha1, Digest};
-
 use rhai::{CustomType, TypeBuilder, EvalAltResult};
 
 mod runtime;
@@ -76,33 +74,13 @@ pub(crate) fn guid_from_provider(provider_name: &str) -> anyhow::Result<Guid> {
                     0x87, 0xF8, 0x1A, 0x15,
                     0xBF, 0xC1, 0x30, 0xFB];
 
-                let mut hasher = Sha1::new();
-
-                hasher.update(&namespace_bytes);
-
+                /* EventSource encodes the name as upper-case UTF-16BE */
+                let mut name_bytes = Vec::with_capacity(provider_name.len() * 2);
                 for c in provider_name.to_uppercase().chars() {
-                    let c = c as u16;
-                    hasher.update(&c.to_be_bytes());
+                    name_bytes.extend_from_slice(&(c as u16).to_be_bytes());
                 }
 
-                let result = hasher.finalize();
-
-                let a = u32::from_ne_bytes(result[0..4].try_into()?);
-                let b = u16::from_ne_bytes(result[4..6].try_into()?);
-                let mut c = u16::from_ne_bytes(result[6..8].try_into()?);
-
-                /* High 4 bits of octet 7 to 5, as per RFC 4122 */
-                c = (c & 0x0FFF) | 0x5000;
-
-                Ok(Guid {
-                    data1: a,
-                    data2: b,
-                    data3: c,
-                    data4: [
-                        result[8], result[9], result[10], result[11],
-                        result[12], result[13], result[14], result[15]
-                    ]
-                })
+                Ok(Guid::v5_from_name(&namespace_bytes, &name_bytes))
             }
         }
     }

--- a/one_collect/src/lib.rs
+++ b/one_collect/src/lib.rs
@@ -36,6 +36,42 @@ impl Guid {
     pub fn to_bytes(&self) -> [u8; 16] {
         unsafe { std::mem::transmute(*self) }
     }
+
+    /// Derive a GUID from a namespace and a name by hashing `namespace ++ name`
+    /// with SHA-1 and laying the digest into the GUID fields (RFC 4122 v5 style).
+    ///
+    /// Only the version nibble is set (to 5); the variant bits are deliberately
+    /// left untouched so the output stays byte-identical to the pre-existing
+    /// `helpers::dotnet::scripting::guid_from_provider` algorithm. This means the
+    /// result is *not* a strictly conformant v5 UUID.
+    ///
+    /// Callers choose the byte encoding of `name` (UTF-8 for ETW session names,
+    /// uppercase UTF-16BE for `EventSource` provider names).
+    pub fn v5_from_name(namespace: &[u8], name: &[u8]) -> Self {
+        use sha1::{Sha1, Digest};
+
+        let mut hasher = Sha1::new();
+        hasher.update(namespace);
+        hasher.update(name);
+        let result = hasher.finalize();
+
+        let a = u32::from_ne_bytes([result[0], result[1], result[2], result[3]]);
+        let b = u16::from_ne_bytes([result[4], result[5]]);
+        let mut c = u16::from_ne_bytes([result[6], result[7]]);
+
+        /* High 4 bits of octet 7 to 5, as per RFC 4122 */
+        c = (c & 0x0FFF) | 0x5000;
+
+        Self {
+            data1: a,
+            data2: b,
+            data3: c,
+            data4: [
+                result[8], result[9], result[10], result[11],
+                result[12], result[13], result[14], result[15],
+            ],
+        }
+    }
 }
 
 pub mod event;
@@ -87,3 +123,38 @@ pub fn io_error(message: &str) -> IOError {
         std::io::ErrorKind::Other,
         message)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Guid;
+
+    const NS: &[u8] = b"one_collect test namespace";
+
+    #[test]
+    fn v5_from_name_is_deterministic() {
+        assert_eq!(
+            Guid::v5_from_name(NS, b"record-trace").to_bytes(),
+            Guid::v5_from_name(NS, b"record-trace").to_bytes());
+    }
+
+    #[test]
+    fn v5_from_name_distinct_names_distinct_guids() {
+        assert_ne!(
+            Guid::v5_from_name(NS, b"session-a").to_bytes(),
+            Guid::v5_from_name(NS, b"session-b").to_bytes());
+    }
+
+    #[test]
+    fn v5_from_name_distinct_namespaces_distinct_guids() {
+        assert_ne!(
+            Guid::v5_from_name(b"namespace-a", b"same-name").to_bytes(),
+            Guid::v5_from_name(b"namespace-b", b"same-name").to_bytes());
+    }
+
+    #[test]
+    fn v5_from_name_sets_version_nibble_to_5() {
+        let guid = Guid::v5_from_name(NS, b"record-trace");
+        assert_eq!(guid.data3 & 0xF000, 0x5000);
+    }
+}
+


### PR DESCRIPTION
Fixes #289 

## Changes

Derive the session GUID deterministically from the session name, using the same SHA-1 / RFC 4122 v5 scheme the crate already uses to map EventSource provider names to provider GUIDs