### PR TITLE
Add `--session-name` flag to record-trace

### DIFF
--- a/record-trace/engine/src/commandline.rs
+++ b/record-trace/engine/src/commandline.rs
@@ -63,6 +63,9 @@ struct Args {
 
     #[arg(long, default_value_t = LogMode::File, help = "Log mode: 'disabled', 'console', or 'file'")]
     log_mode: LogMode,
+
+    #[arg(long, help = "Session name to record under. Defaults to \"record-trace\". On Windows this names the ETW session: a fixed name limits the machine to one record-trace session at a time but lets a new run reclaim a session left behind by a crashed one, while a unique name (e.g. per-PID) allows multiple concurrent sessions. On Linux the name is just a label (perf sessions are scoped per PID/CPU, so concurrent runs already work).")]
+    session_name: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -114,6 +117,7 @@ pub struct RecordArgs {
     log_filter: Option<String>,
     log_path: Option<String>,
     log_mode: LogMode,
+    session_name: String,
 }
 
 impl RecordArgs {
@@ -172,6 +176,8 @@ impl RecordArgs {
             log_filter: command_args.log_filter,
             log_path: command_args.log_path,
             log_mode: command_args.log_mode,
+            session_name: command_args.session_name
+                .unwrap_or_else(|| String::from("record-trace")),
         };
 
         // Cross-argument validation.
@@ -249,6 +255,10 @@ impl RecordArgs {
         self.log_mode
     }
 
+    pub (crate) fn session_name(&self) -> &str {
+        &self.session_name
+    }
+
     pub fn write_to_log(&self) {
         info!("Arguments parsed: output_path={}", self.output_path.display());
         info!("Arguments parsed: format={}", self.format);
@@ -276,6 +286,7 @@ impl RecordArgs {
             info!("Arguments parsed: log_path={}", path);
         }
         info!("Arguments parsed: log_mode={}", self.log_mode);
+        info!("Arguments parsed: session_name={}", self.session_name);
         if let Some(ref script) = self.script {
             info!("Arguments parsed: script start");
             info!("{}", script);

--- a/record-trace/engine/src/recorder.rs
+++ b/record-trace/engine/src/recorder.rs
@@ -350,7 +350,7 @@ impl Recorder {
             None => None,
         };
 
-        let parse_result = universal.parse_until("record-trace", move || {
+        let parse_result = universal.parse_until(self.args.session_name(), move || {
             // Print the banner telling the user that recording has started.
             if print_banner.load(Ordering::SeqCst) {
                 print_banner.store(false, Ordering::SeqCst);


### PR DESCRIPTION
Addresses https://github.com/microsoft/one-collect/issues/289#issuecomment-4712821835

## Changes

Adds an optional `--session-name <name>` flag to `record-trace` that sets the ETW/perf session name used for recording. Defaults to `"record-trace"` when omitted, preserving current behavior.

## Motivation

`record-trace` previously hardcoded the session name `"record-trace"`. On Windows, after the GUID-from-name fix (#289), the session name determines the session's identity:

- A fixed name (the default) means one `record-trace` ETW session per machine at a time, but a new run automatically reclaims a session left behind by a crashed one.
- A unique name (e.g. per-PID) lets multiple `record-trace` ETW sessions run side by side.

On Linux the name has no such constraint. perf sessions are scoped per PID/CPU, so concurrent runs already work regardless of name. The flag is primarily a Windows concurrency control and reads as a harmless session label on Linux.

This flag lets users opt into concurrent recording on Windows when they need it, while keeping the safe singleton + crash-recovery default for the common case.