### PR TITLE
Add support for emitting cgroup IDs from perf events

### DIFF
--- a/one_collect/src/helpers/exporting/attributes.rs
+++ b/one_collect/src/helpers/exporting/attributes.rs
@@ -333,6 +333,53 @@ impl ExportAttributeSource for ActivityIdAttributeSource {
     }
 }
 
+#[derive(Default)]
+pub struct CgroupAttributeSource {
+    attributes_cache: HashMap<u64, usize>,
+    cgroup_str_id: usize,
+}
+
+impl ExportAttributeSource for CgroupAttributeSource {
+    fn initialize(
+        &mut self,
+        machine: &mut ExportMachine) {
+        self.cgroup_str_id = machine.intern("CGroup");
+    }
+
+    fn add_attributes(
+        &mut self,
+        trace: &mut ExportTraceContext,
+        attributes: &mut ExportAttributes) -> anyhow::Result<()> {
+        let cgroup_id = trace.cgroup()?.unwrap_or(0);
+
+        if cgroup_id != 0 {
+            let attribute_id = match self.attributes_cache.entry(cgroup_id) {
+                Vacant(entry) => {
+                    let mut attributes = ExportAttributes::default();
+
+                    attributes.push(
+                        ExportAttributePair::new(
+                            self.cgroup_str_id,
+                            ExportAttributeValue::Value(cgroup_id)));
+
+                    let id = trace.push_unique_attributes(attributes);
+
+                    entry.insert(id);
+
+                    id
+                },
+                Occupied(entry) => {
+                    *entry.get()
+                },
+            };
+
+            attributes.push_association(attribute_id);
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -196,6 +196,12 @@ pub trait ExportSamplerOSHooks {
     fn os_event_related_activity_id(
         &self,
         data: &EventData) -> anyhow::Result<Option<[u8; 16]>>;
+
+    fn os_event_cgroup(
+        &self,
+        _data: &EventData) -> anyhow::Result<Option<u64>> {
+        Ok(None)
+    }
 }
 
 impl ExportSampler {
@@ -348,14 +354,19 @@ impl ExportSampler {
 
         let time = self.os_event_time(data)?;
         let cpu = self.os_event_cpu(data)?;
+        let cgroup_id = self.os_event_cgroup(data)?.unwrap_or(0);
 
-        Ok(self.exporter.borrow_mut().make_sample(
+        let mut sample = self.exporter.borrow_mut().make_sample(
             time,
             value,
             tid,
             cpu,
             kind,
-            &self.frames))
+            &self.frames);
+
+        sample.set_cgroup_id(cgroup_id);
+
+        Ok(sample)
     }
 
     fn add_custom_sample(
@@ -939,6 +950,8 @@ impl<'a> ExportSampleFilterContext<'a> {
     }
 
     pub fn pid(&self) -> u32 { self.proc.pid() }
+
+    pub fn cgroup_id(&self) -> u64 { self.sample.cgroup_id() }
 
     pub fn sample_record_data(&self) -> Option<ExportRecordData<'_>> {
         if self.record_data.is_none() {

--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -38,6 +38,7 @@ use attributes::ExportAttributeWalker;
 use attributes::VersionOpCodeAttributeSource;
 use attributes::TraceContextAttributeSource;
 use attributes::ActivityIdAttributeSource;
+use attributes::CgroupAttributeSource;
 
 pub mod span;
 use span::ExportSpan;
@@ -354,17 +355,14 @@ impl ExportSampler {
 
         let time = self.os_event_time(data)?;
         let cpu = self.os_event_cpu(data)?;
-        let cgroup_id = self.os_event_cgroup(data)?.unwrap_or(0);
 
-        let mut sample = self.exporter.borrow_mut().make_sample(
+        let sample = self.exporter.borrow_mut().make_sample(
             time,
             value,
             tid,
             cpu,
             kind,
             &self.frames);
-
-        sample.set_cgroup_id(cgroup_id);
 
         Ok(sample)
     }
@@ -738,6 +736,10 @@ impl<'a> ExportTraceContext<'a> {
         self.sampler.borrow().related_activity_id(self.data)
     }
 
+    pub fn cgroup(&self) -> anyhow::Result<Option<u64>> {
+        self.sampler.borrow().os_event_cgroup(self.data)
+    }
+
     pub fn record_type(
         &mut self,
         record_type: ExportRecordType) -> u16 {
@@ -913,6 +915,7 @@ pub struct ExportSampleFilterContext<'a> {
     record_type_id: u16,
     record_data: Option<&'a [u8]>,
     strings: &'a InternedStrings,
+    attributes: &'a Vec<ExportAttributes>,
     proc: &'a ExportProcess,
     sample: &'a ExportProcessSample,
 }
@@ -951,7 +954,47 @@ impl<'a> ExportSampleFilterContext<'a> {
 
     pub fn pid(&self) -> u32 { self.proc.pid() }
 
-    pub fn cgroup_id(&self) -> u64 { self.sample.cgroup_id() }
+    pub fn cgroup_id(&self) -> u64 {
+        let attributes_id = self.sample.attributes_id();
+        if attributes_id == 0 {
+            return 0;
+        }
+
+        let cgroup_name_id = match self.strings.find_id("CGroup") {
+            Some(id) => id,
+            None => return 0,
+        };
+
+        /* Walk the attributes tree for this sample */
+        let mut seen = HashSet::new();
+        let mut stack = vec![attributes_id];
+
+        while let Some(id) = stack.pop() {
+            if !seen.insert(id) {
+                continue;
+            }
+
+            if id >= self.attributes.len() {
+                continue;
+            }
+
+            let attrs = &self.attributes[id];
+
+            for pair in attrs.attributes() {
+                if pair.name() == cgroup_name_id {
+                    if let Some(value) = pair.value() {
+                        return value;
+                    }
+                }
+            }
+
+            for associated_id in attrs.associated_ids() {
+                stack.push(*associated_id);
+            }
+        }
+
+        0
+    }
 
     pub fn sample_record_data(&self) -> Option<ExportRecordData<'_>> {
         if self.record_data.is_none() {
@@ -1005,6 +1048,7 @@ macro_rules! filter_sample_ret_on_drop {
                 record_type_id: $record_type_id,
                 record_data: $record_data,
                 spans: &$self.spans,
+                attributes: &$self.attributes,
                 proc: $proc,
                 sample: $sample,
             };
@@ -1161,6 +1205,11 @@ impl ExportSettings {
     pub fn with_activity_id_attributes(self) -> Self {
         self.with_attribute_source(
             Box::new(ActivityIdAttributeSource::default()))
+    }
+
+    pub fn with_cgroup_attributes(self) -> Self {
+        self.with_attribute_source(
+            Box::new(CgroupAttributeSource::default()))
     }
 
     pub fn with_event(

--- a/one_collect/src/helpers/exporting/mod.rs
+++ b/one_collect/src/helpers/exporting/mod.rs
@@ -833,7 +833,7 @@ impl<'a> ExportTraceContext<'a> {
         let associated_ids = attributes.associated_ids();
         let new_attributes = attributes.attributes();
 
-        let attribute_id = if !new_attributes.is_empty() || !associated_ids.len() > 1 {
+        let attribute_id = if !new_attributes.is_empty() || associated_ids.len() > 1 {
             /*
              * Multiple items, always save new attributes:
              * At some point we could look at caching these if needed. Many

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -17,6 +17,7 @@ use crate::openat::{OpenAt, DupFd};
 use crate::procfs;
 use crate::perf_event::{AncillaryData, PerfSession};
 use crate::perf_event::{RingBufSessionBuilder, RingBufBuilder};
+use crate::perf_event::rb::RingBufOptions;
 use crate::perf_event::abi::PERF_RECORD_MISC_SWITCH_OUT;
 use crate::helpers::callstack::{CallstackHelp, CallstackReader};
 use crate::helpers::exporting::*;
@@ -658,6 +659,7 @@ pub(crate) struct OSExportSampler {
     time_field: DataFieldRef,
     pid_field: DataFieldRef,
     tid_field: DataFieldRef,
+    cgroup_field: DataFieldRef,
 }
 
 impl OSExportSampler {
@@ -670,6 +672,7 @@ impl OSExportSampler {
             time_field: session.time_data_ref(),
             pid_field: session.pid_field_ref(),
             tid_field: session.tid_data_ref(),
+            cgroup_field: session.cgroup_data_ref(),
         }
     }
 }
@@ -740,6 +743,12 @@ impl ExportSamplerOSHooks for ExportSampler {
         &self,
         _data: &EventData) -> anyhow::Result<Option<[u8; 16]>> {
         Ok(None)
+    }
+
+    fn os_event_cgroup(
+        &self,
+        data: &EventData) -> anyhow::Result<Option<u64>> {
+        Ok(self.os.cgroup_field.try_get_u64(data.full_data()))
     }
 
     fn os_event_callstack(
@@ -1674,7 +1683,8 @@ impl ExportBuilderHelp for RingBufSessionBuilder {
         }
 
         if settings.events.is_some() {
-            let tracepoint = RingBufBuilder::for_tracepoint();
+            let tracepoint = RingBufBuilder::for_tracepoint()
+                .with_cgroup_data();
 
             builder = builder.with_tracepoint_events(tracepoint);
         }

--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -17,7 +17,7 @@ use crate::openat::{OpenAt, DupFd};
 use crate::procfs;
 use crate::perf_event::{AncillaryData, PerfSession};
 use crate::perf_event::{RingBufSessionBuilder, RingBufBuilder};
-use crate::perf_event::rb::RingBufOptions;
+use crate::perf_event::rb::{RingBufOptions, cgroup_sample_supported};
 use crate::perf_event::abi::PERF_RECORD_MISC_SWITCH_OUT;
 use crate::helpers::callstack::{CallstackHelp, CallstackReader};
 use crate::helpers::exporting::*;
@@ -1683,8 +1683,11 @@ impl ExportBuilderHelp for RingBufSessionBuilder {
         }
 
         if settings.events.is_some() {
-            let tracepoint = RingBufBuilder::for_tracepoint()
-                .with_cgroup_data();
+            let mut tracepoint = RingBufBuilder::for_tracepoint();
+
+            if cgroup_sample_supported() {
+                tracepoint = tracepoint.with_cgroup_data();
+            }
 
             builder = builder.with_tracepoint_events(tracepoint);
         }

--- a/one_collect/src/helpers/exporting/process.rs
+++ b/one_collect/src/helpers/exporting/process.rs
@@ -333,6 +333,7 @@ pub struct ExportProcessSample {
     callstack_id: u32,
     record_id: u32,
     attributes_id: u32,
+    cgroup_id: u64,
 }
 
 impl ExportProcessSample {
@@ -356,6 +357,7 @@ impl ExportProcessSample {
             callstack_id,
             record_id: 0,
             attributes_id: 0,
+            cgroup_id: 0,
         }
     }
 
@@ -396,6 +398,10 @@ impl ExportProcessSample {
         attributes_id: usize) {
         self.attributes_id = attributes_id as u32;
     }
+
+    pub fn cgroup_id(&self) -> u64 { self.cgroup_id }
+
+    pub fn set_cgroup_id(&mut self, id: u64) { self.cgroup_id = id; }
 }
 
 const EXPORT_PROCESS_FLAG_CREATED: u8 = 1 << 0;

--- a/one_collect/src/helpers/exporting/process.rs
+++ b/one_collect/src/helpers/exporting/process.rs
@@ -333,7 +333,6 @@ pub struct ExportProcessSample {
     callstack_id: u32,
     record_id: u32,
     attributes_id: u32,
-    cgroup_id: u64,
 }
 
 impl ExportProcessSample {
@@ -357,7 +356,6 @@ impl ExportProcessSample {
             callstack_id,
             record_id: 0,
             attributes_id: 0,
-            cgroup_id: 0,
         }
     }
 
@@ -398,10 +396,6 @@ impl ExportProcessSample {
         attributes_id: usize) {
         self.attributes_id = attributes_id as u32;
     }
-
-    pub fn cgroup_id(&self) -> u64 { self.cgroup_id }
-
-    pub fn set_cgroup_id(&mut self, id: u64) { self.cgroup_id = id; }
 }
 
 const EXPORT_PROCESS_FLAG_CREATED: u8 = 1 << 0;

--- a/one_collect/src/perf_event/mod.rs
+++ b/one_collect/src/perf_event/mod.rs
@@ -344,6 +344,7 @@ pub struct PerfSession {
     branch_stack_field: DataFieldRef,
     regs_user_field: DataFieldRef,
     stack_user_field: DataFieldRef,
+    cgroup_field: DataFieldRef,
 
     /* Options */
     read_timeout: Duration,
@@ -442,6 +443,7 @@ impl PerfSession {
             branch_stack_field: DataFieldRef::new(),
             regs_user_field: DataFieldRef::new(),
             stack_user_field: DataFieldRef::new(),
+            cgroup_field: DataFieldRef::new(),
 
             /* BPF */
             bpf_events: HashMap::new(),
@@ -604,6 +606,10 @@ impl PerfSession {
 
     pub fn stack_user_data_ref(&self) -> DataFieldRef {
         self.stack_user_field.clone()
+    }
+
+    pub fn cgroup_data_ref(&self) -> DataFieldRef {
+        self.cgroup_field.clone()
     }
 
     pub fn set_read_timeout(
@@ -1085,6 +1091,35 @@ impl PerfSession {
                 }
 
                 /* TODO: Remaining abi format types */
+
+                /*
+                 * Fields decode in ABI bit order by advancing `offset`, so cgroup (bit 21)
+                 * is only at `offset` when nothing between STACK_USER (bit 13) and it is
+                 * enabled. No builder enables those, so parse directly; else drop (reset).
+                 */
+                const UNPARSED_SAMPLE_FIELDS_BEFORE_CGROUP: u64 =
+                    abi::PERF_SAMPLE_WEIGHT |
+                    abi::PERF_SAMPLE_DATA_SRC |
+                    abi::PERF_SAMPLE_TRANSACTION |
+                    abi::PERF_SAMPLE_REGS_INTR |
+                    abi::PERF_SAMPLE_PHYS_ADDR;
+
+                /* PERF_SAMPLE_CGROUP */
+                if perf_data.has_format(abi::PERF_SAMPLE_CGROUP) {
+                    let sample_type = perf_data.ancillary.attributes.sample_type;
+                    debug_assert_eq!(
+                        sample_type & UNPARSED_SAMPLE_FIELDS_BEFORE_CGROUP, 0,
+                        "a builder enabled a sample field between STACK_USER and CGROUP; \
+                         the cgroup parser needs explicit skip logic for it");
+                    if (sample_type & UNPARSED_SAMPLE_FIELDS_BEFORE_CGROUP) != 0 {
+                        warn!("Skipping PERF_SAMPLE_CGROUP: unparsed sample fields precede it");
+                        self.cgroup_field.reset();
+                    } else {
+                        offset += self.cgroup_field.update(offset, 8);
+                    }
+                } else {
+                    self.cgroup_field.reset();
+                }
 
                 /* For now print warning if we see this */
                 if offset > perf_data.raw_data.len() {
@@ -1954,4 +1989,59 @@ mod tests {
             other => panic!("expected UnknownCpu(7), got {other:?}"),
         }
     }
+    #[test]
+    fn mock_data_cgroup_field() {
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let sample_format =
+            abi::PERF_SAMPLE_TIME |
+            abi::PERF_SAMPLE_CGROUP |
+            abi::PERF_SAMPLE_RAW;
+
+        let mut mock = MockData::new(sample_format, 0);
+        let mut perf_data = Vec::new();
+        let mut raw_data = Vec::new();
+
+        let id: u16 = 1;
+        let time: u64 = 9999;
+        let cgroup_id: u64 = 404228;
+
+        /* PERF_SAMPLE_TIME */
+        Sample::write_time(time, &mut raw_data);
+
+        /* PERF_SAMPLE_RAW */
+        let id_bytes = id.to_ne_bytes();
+        let field_size = 4 + id_bytes.len();
+        raw_data.extend_from_slice(&(id_bytes.len() as u32).to_ne_bytes());
+        raw_data.extend_from_slice(&id_bytes);
+        raw_data.resize(raw_data.len() + abi::align_to_perf_record(field_size) - field_size, 0);
+
+        /* PERF_SAMPLE_CGROUP */
+        raw_data.extend_from_slice(&cgroup_id.to_ne_bytes());
+
+        Header::write(abi::PERF_RECORD_SAMPLE, 0, raw_data.as_slice(), &mut perf_data);
+        mock.push(perf_data.as_slice());
+
+        let mut session = PerfSession::new(Box::new(mock));
+        let mut e = Event::new(id as usize, "test".into());
+
+        let cgroup_data = session.cgroup_data_ref();
+        let time_data = session.time_data_ref();
+        let callback_count = Arc::clone(&count);
+
+        e.add_callback(move |data| {
+            let full_data = data.full_data();
+
+            assert_eq!(Some(time), time_data.try_get_u64(full_data));
+            assert_eq!(Some(cgroup_id), cgroup_data.try_get_u64(full_data));
+
+            callback_count.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        });
+
+        session.add_event(e).unwrap();
+        session.parse_all().unwrap();
+        assert_eq!(1, count.load(Ordering::Relaxed));
+    }
+
 }

--- a/one_collect/src/perf_event/rb/mod.rs
+++ b/one_collect/src/perf_event/rb/mod.rs
@@ -103,6 +103,15 @@ pub trait RingBufOptions {
 
         clone
     }
+
+    fn with_cgroup_data(&self) -> Self where Self: Sized {
+        let mut clone = self.clone_options();
+        let attributes = clone.attributes_mut();
+
+        attributes.sample_type |= abi::PERF_SAMPLE_CGROUP;
+
+        clone
+    }
 }
 
 pub fn cpu_count() -> u32 {

--- a/one_collect/src/perf_event/rb/mod.rs
+++ b/one_collect/src/perf_event/rb/mod.rs
@@ -114,6 +114,52 @@ pub trait RingBufOptions {
     }
 }
 
+/// Determine whether cgroup ids can be recorded in samples.
+///
+/// This is done by checking whether the running Linux kernel supports
+/// `PERF_SAMPLE_CGROUP`, which was added in kernel 5.7+. We check
+/// this separately, otherwise `perf_event_open` would fail fatally.
+pub(crate) fn cgroup_sample_supported() -> bool {
+    let attr = perf_event_attr {
+        size: PERF_ATTR_SIZE_VER4,
+        event_type: PERF_TYPE_SOFTWARE,
+        config: PERF_COUNT_SW_DUMMY,
+        sample_type: abi::PERF_SAMPLE_CGROUP,
+        flags: FLAG_DISABLED,
+        .. Default::default()
+    };
+
+    // SAFETY: `attr` is the fully initialized perf_event_attr that
+    // outlives the call. The syscall only reads through the pointer
+    // and returns an fd or -1.
+    let result = unsafe {
+        syscall(
+            SYS_perf_event_open,
+            &attr as *const perf_event_attr as usize,
+            0,                /* pid: calling process */
+            (-1i32) as usize, /* cpu: any */
+            (-1i32) as usize, /* group_fd: none */
+            0)
+    };
+
+    if result >= 0 {
+        // SAFETY: `result` is an fd we just opened and solely own.
+        // Closed once now.
+        unsafe { close(result as i32); }
+        true
+    } else {
+        let err = std::io::Error::last_os_error();
+
+        if err.raw_os_error() == Some(EINVAL) {
+            warn!("PERF_SAMPLE_CGROUP unsupported; cgroup ids will not be recorded");
+            false
+        } else {
+            /* Not a kernel support failure (but, e.g., permissions) */
+            true
+        }
+    }
+}
+
 pub fn cpu_count() -> u32 {
     unsafe {
         const SC_NPROCESSORS_ONLN: i32 = 84;

--- a/record-trace/engine/src/recorder.rs
+++ b/record-trace/engine/src/recorder.rs
@@ -222,6 +222,11 @@ impl Recorder {
                     context.comm_name(),
                     context.pid());
 
+                let cgroup_id = context.cgroup_id();
+                if cgroup_id != 0 {
+                    let _ = write!(line, "CGroup={} ", cgroup_id);
+                }
+
                 match context.sample().value() {
                     MetricValue::Count(count) => {
                         append_count(count, &mut line);

--- a/record-trace/engine/src/recorder.rs
+++ b/record-trace/engine/src/recorder.rs
@@ -94,7 +94,8 @@ impl Recorder {
         let mut settings = ExportSettings::default()
             .with_version_attributes()
             .with_trace_context_attributes()
-            .with_activity_id_attributes();
+            .with_activity_id_attributes()
+            .with_cgroup_attributes();
 
         // CPU sampling.
         if self.args.on_cpu() {


### PR DESCRIPTION
This patch makes it possible to record the cgroup ID that perf reports on each tracepoint sample. To do so, we add a builder, `with_cgroup_data()`, that sets `PERF_SAMPLE_CGROUP` on the session (if we confirm that it has kernel support via probing). The cgroup ID is then surfaced as an attribute (`CgroupAttributeSource`) and printed by record-trace.

`PERF_SAMPLE_CGROUP` [has been part of perf_event_open(2)](https://manpages.debian.org/testing/manpages-dev/perf_event_open.2.en.html#PERF_SAMPLE_CGROUP) since Linux 5.7. When it is set, the kernel records the cgroup ID of the sampled task on every sample. one-collect [already defines](https://github.com/microsoft/one-collect/blob/598ac7172004b9c13f0412d96befe3d3986ad81d/one_collect/src/perf_event/abi.rs#L67) the PERF_SAMPLE_CGROUP constant in its ABI definitions, but it never set the bit or read the value.

For our use cases, we need to attribute each event back to the service that caused it to fire. Today we can do that attribution on the PID from the event, but PIDs get reused and the PIDs of forked processes/children have to be looked up again. With this change, each event would carry the cgroup id of the originating task, so it would let us attribute the connection to the cgroup (of its systemd service)easily.

Closes #174.

## Usage

This behavior is enabled by default. However, unlike the other optional sample fields, `with_cgroup_data()` can fail outright on kernels before 5.7, so we request it only after a kernel-support probe succeeds. Before turning it on for a session, we open a throwaway perf event with just that sample bit set. If the kernel accepts it, we obtain the cgroup ID on every sample.

A consumer can read it off the sample with `context.cgroup_id()`. Or, for a usual record-trace script like so:

```rust
let ev = event_from_tracefs("syscalls", "sys_enter_write");
record_event(ev);
```

Running record-trace in the background gives you something like this:

> +1.0023: syscalls/sys_enter_write(seq, PID=2776273): **CGroup=6533** 1 Count
> +1.0024: syscalls/sys_enter_write(seq, PID=2776273): **CGroup=6533** 1 Count

## Performance implications

The change adds very little to the per-sample hot path. When cgroup capture is on, each tracepoint sample does one extra 8-byte read at a known offset in the sample record.

To measure how much CPU time that this would add to record_trace, I start with a small program to generate some syscall traffic (here I do a million `write(2)`s):

```c
#include <fcntl.h>
#include <stdlib.h>
#include <unistd.h>

int main(int argc, char **argv)
{
    long writes = (argc > 1) ? atol(argv[1]) : 1000000L;
    double delay = (argc > 2) ? atof(argv[2]) : 1.0;

    usleep((useconds_t)(delay * 1e6));

    int fd = open("/dev/null", O_WRONLY);
    char b = 'x';
    for (long i = 0; i < writes; i++) {
        if (write(fd, &b, 1) < 0) {
            return 1;
        }
    }
    return 0;
}
```
Then, I use a script like the following to repeatedly invoke trials of record-trace, against either the main branch build or my feature branch build. The time that it measures is off of record-trace's own PID:

```python
def trial(binary):
    gen = subprocess.Popen(["/tmp/perf_gen", "1000000", "1.0"])
    time.sleep(0.2)
    rt = subprocess.Popen(
        [binary, "--script-file", "/tmp/perf.script", "--pid", str(gen.pid),
        "--out", "/tmp/rtout", "--log-mode", "disabled"],
        stdout=subprocess.DEVNULL,
        stderr=subprocess.DEVNULL,
    )
    gen.wait()
    time.sleep(0.3)
    os.kill(rt.pid, signal.SIGINT)
    _, _, usage = os.wait4(rt.pid, 0)
    return usage.ru_utime + usage.ru_stime
```

After 30 interleaved trials each:

| Version | n   | mean    | sd     | median |
| ------- | --- | ------- | ------ | ------ |
| main    | 30  | 0.1439s | 0.0233 | 0.1396 |
| after   | 30  | 0.1295s | 0.0231 | 0.1248 |

We are actually marginally faster than main (Δ = -0.014s, -~10%), because a `default_attributes` bug fix eliminates a per-sample wrapper allocation that was costing cycles on main.