### PR TITLE
Fix `one_collect` compilation with `--no-default-features`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,11 @@ jobs:
     - name: 'one_collect: Build'
       working-directory: one_collect
       run: cargo build --locked ${{ inputs.build-flavor == 'release' && '--release' || '' }} --verbose
-    
+
+    - name: 'one_collect: Build (no default features)'
+      working-directory: one_collect
+      run: cargo build --locked --no-default-features ${{ inputs.build-flavor == 'release' && '--release' || '' }} --verbose
+
     - name: 'one_collect: Run tests'
       working-directory: one_collect
       run: cargo test --locked ${{ inputs.build-flavor == 'release' && '--release' || '' }} --verbose

--- a/one_collect/src/helpers/dotnet/mod.rs
+++ b/one_collect/src/helpers/dotnet/mod.rs
@@ -4,6 +4,8 @@
 pub mod os;
 use os::OSDotNetHelper;
 
+pub(crate) mod provider;
+
 #[cfg(feature = "scripting")]
 pub mod scripting;
 

--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -31,7 +31,7 @@ use crate::Writable;
 use crate::procfs;
 use crate::event::*;
 
-use crate::helpers::dotnet::scripting::*;
+use crate::helpers::dotnet::provider::{DotNetProviderFlags, guid_from_provider, event_full_name};
 use crate::helpers::dotnet::nettrace;
 
 use tracing::{warn, info, debug};

--- a/one_collect/src/helpers/dotnet/os/windows.rs
+++ b/one_collect/src/helpers/dotnet/os/windows.rs
@@ -9,7 +9,6 @@ use std::collections::hash_map::Entry::{Vacant, Occupied};
 use crate::helpers::dotnet::*;
 use crate::helpers::dotnet::universal::UniversalDotNetHelperOSHooks;
 
-#[cfg(feature = "scripting")]
 use crate::helpers::exporting::UniversalExporter;
 
 use crate::helpers::exporting::record::*;
@@ -22,7 +21,7 @@ use crate::event::os::windows::WindowsEventExtension;
 
 use crate::etw::{EtwSession, AncillaryData};
 
-use crate::helpers::dotnet::scripting::*;
+use crate::helpers::dotnet::provider::{DotNetProviderFlags, guid_from_provider, event_full_name};
 use crate::Guid;
 
 use tracing::{warn, debug};

--- a/one_collect/src/helpers/dotnet/provider.rs
+++ b/one_collect/src/helpers/dotnet/provider.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use crate::Guid;
+
+pub(crate) fn event_full_name(provider_name: &str, guid: Guid, event_name: &str) -> String {
+    use std::fmt::Write;
+
+    let mut full = String::new();
+
+    full.push_str(provider_name);
+    full.push_str(":{");
+
+    let _ = write!(
+        full,
+        "{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}",
+        guid.data1, guid.data2, guid.data3,
+        guid.data4[0], guid.data4[1], guid.data4[2], guid.data4[3],
+        guid.data4[4], guid.data4[5], guid.data4[6], guid.data4[7]);
+
+    full.push_str("}/");
+    full.push_str(event_name);
+
+    full
+}
+
+pub(crate) fn guid_from_provider(provider_name: &str) -> anyhow::Result<Guid> {
+    match provider_name {
+        "Microsoft-Windows-DotNETRuntime" => {
+            Ok(Guid::from_u128(0xe13c0d23_ccbc_4e12_931b_d9cc2eee27e4))
+        },
+        "Microsoft-Windows-DotNETRuntimeRundown" => {
+            Ok(Guid::from_u128(0xA669021C_C450_4609_A035_5AF59AF4DF18))
+        },
+        "Microsoft-Windows-DotNETRuntimeStress" => {
+            Ok(Guid::from_u128(0xCC2BCBBA_16B6_4cf3_8990_D74C2E8AF500))
+        },
+        "Microsoft-Windows-DotNETRuntimePrivate" => {
+            Ok(Guid::from_u128(0x763FD754_7086_4dfe_95EB_C01A46FAF4CA))
+        },
+        "Microsoft-DotNETRuntimeMonoProfiler" => {
+            Ok(Guid::from_u128(0x7F442D82_0F1D_5155_4B8C_1529EB2E31C2))
+        },
+        _ => {
+            if provider_name.starts_with("{") {
+                /* Direct Guid */
+                let provider = provider_name
+                    .replace("-", "")
+                    .replace("{", "")
+                    .replace("}", "");
+
+                match u128::from_str_radix(provider.trim(), 16) {
+                    Ok(provider) => { Ok(Guid::from_u128(provider)) },
+                    Err(_) => { anyhow::bail!("Invalid provider format."); }
+                }
+            } else {
+                /* Event Source */
+                let namespace_bytes: [u8; 16] = [
+                    0x48, 0x2C, 0x2D, 0xB2,
+                    0xC3, 0x90, 0x47, 0xC8,
+                    0x87, 0xF8, 0x1A, 0x15,
+                    0xBF, 0xC1, 0x30, 0xFB];
+
+                /* EventSource encodes the name as upper-case UTF-16BE */
+                let mut name_bytes = Vec::with_capacity(provider_name.len() * 2);
+                for c in provider_name.to_uppercase().chars() {
+                    name_bytes.extend_from_slice(&(c as u16).to_be_bytes());
+                }
+
+                Ok(Guid::v5_from_name(&namespace_bytes, &name_bytes))
+            }
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+pub(crate) struct DotNetProviderFlags {
+    callstacks: bool,
+    callstack_keywords: u64,
+}
+
+impl DotNetProviderFlags {
+    #[cfg(feature = "scripting")]
+    pub(crate) const fn with_callstacks(&mut self) {
+        self.callstacks = true;
+        self.callstack_keywords = u64::MAX;
+    }
+
+    #[cfg(feature = "scripting")]
+    pub(crate) const fn with_callstacks_for_keywords(
+        &mut self,
+        keywords: u64) {
+        self.callstacks = true;
+        self.callstack_keywords = keywords;
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn callstacks(&self) -> bool { self.callstacks }
+
+    #[allow(dead_code)]
+    pub(crate) fn callstack_keywords(&self) -> u64 { self.callstack_keywords }
+}

--- a/one_collect/src/helpers/dotnet/scripting/mod.rs
+++ b/one_collect/src/helpers/dotnet/scripting/mod.rs
@@ -7,84 +7,14 @@ use crate::helpers::exporting::{
 use crate::helpers::exporting::scripting::UniversalExporterSwapper;
 use crate::helpers::exporting::process::MetricValue;
 use crate::helpers::dotnet::os::OSDotNetEventFactory;
+use crate::helpers::dotnet::provider::DotNetProviderFlags;
 use crate::event::Event;
 use crate::scripting::ScriptEvent;
 use crate::Writable;
-use crate::Guid;
 
 use rhai::{CustomType, TypeBuilder, EvalAltResult};
 
 mod runtime;
-
-pub(crate) fn event_full_name(provider_name: &str, guid: Guid, event_name: &str) -> String {
-    use std::fmt::Write;
-
-    let mut full = String::new();
-
-    full.push_str(provider_name);
-    full.push_str(":{");
-
-    let _ = write!(
-        full,
-        "{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}",
-        guid.data1, guid.data2, guid.data3,
-        guid.data4[0], guid.data4[1], guid.data4[2], guid.data4[3],
-        guid.data4[4], guid.data4[5], guid.data4[6], guid.data4[7]);
-
-    full.push_str("}/");
-    full.push_str(event_name);
-
-    full
-}
-
-pub(crate) fn guid_from_provider(provider_name: &str) -> anyhow::Result<Guid> {
-    match provider_name {
-        "Microsoft-Windows-DotNETRuntime" => {
-            Ok(Guid::from_u128(0xe13c0d23_ccbc_4e12_931b_d9cc2eee27e4))
-        },
-        "Microsoft-Windows-DotNETRuntimeRundown" => {
-            Ok(Guid::from_u128(0xA669021C_C450_4609_A035_5AF59AF4DF18))
-        },
-        "Microsoft-Windows-DotNETRuntimeStress" => {
-            Ok(Guid::from_u128(0xCC2BCBBA_16B6_4cf3_8990_D74C2E8AF500))
-        },
-        "Microsoft-Windows-DotNETRuntimePrivate" => {
-            Ok(Guid::from_u128(0x763FD754_7086_4dfe_95EB_C01A46FAF4CA))
-        },
-        "Microsoft-DotNETRuntimeMonoProfiler" => {
-            Ok(Guid::from_u128(0x7F442D82_0F1D_5155_4B8C_1529EB2E31C2))
-        },
-        _ => {
-            if provider_name.starts_with("{") {
-                /* Direct Guid */
-                let provider = provider_name
-                    .replace("-", "")
-                    .replace("{", "")
-                    .replace("}", "");
-
-                match u128::from_str_radix(provider.trim(), 16) {
-                    Ok(provider) => { Ok(Guid::from_u128(provider)) },
-                    Err(_) => { anyhow::bail!("Invalid provider format."); }
-                }
-            } else {
-                /* Event Source */
-                let namespace_bytes: [u8; 16] = [
-                    0x48, 0x2C, 0x2D, 0xB2,
-                    0xC3, 0x90, 0x47, 0xC8,
-                    0x87, 0xF8, 0x1A, 0x15,
-                    0xBF, 0xC1, 0x30, 0xFB];
-
-                /* EventSource encodes the name as upper-case UTF-16BE */
-                let mut name_bytes = Vec::with_capacity(provider_name.len() * 2);
-                for c in provider_name.to_uppercase().chars() {
-                    name_bytes.extend_from_slice(&(c as u16).to_be_bytes());
-                }
-
-                Ok(Guid::v5_from_name(&namespace_bytes, &name_bytes))
-            }
-        }
-    }
-}
 
 pub (crate) struct DotNetSample {
     event: Event,
@@ -132,32 +62,6 @@ impl DotNetEventGroup {
 
         self.events.push(event);
     }
-}
-
-#[derive(Default, Clone)]
-pub (crate) struct DotNetProviderFlags {
-    callstacks: bool,
-    callstack_keywords: u64,
-}
-
-impl DotNetProviderFlags {
-    const fn with_callstacks(&mut self) {
-        self.callstacks = true;
-        self.callstack_keywords = u64::MAX;
-    }
-
-    const fn with_callstacks_for_keywords(
-        &mut self,
-        keywords: u64) {
-        self.callstacks = true;
-        self.callstack_keywords = keywords;
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn callstacks(&self) -> bool { self.callstacks }
-
-    #[allow(dead_code)]
-    pub(crate) fn callstack_keywords(&self) -> u64 { self.callstack_keywords }
 }
 
 impl CustomType for DotNetProviderFlags {
@@ -355,6 +259,7 @@ impl DotNetScripting for ScriptedUniversalExporter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::helpers::dotnet::provider::{guid_from_provider, event_full_name};
     use crate::helpers::exporting::ExportSettings;
 
     #[test]


### PR DESCRIPTION
## Problem

Building `one_collect` with `--no-default-features` fails to compile on both Linux and Windows:

```shell
error[E0432]: unresolved import `crate::helpers::dotnet::scripting`
  --> src/helpers/dotnet/os/linux.rs:34:29
   |
34 | use crate::helpers::dotnet::scripting::*;
   |                             ^^^^^^^^^ could not find `scripting` in `dotnet`
```

Windows has the same root break, plus a second latent one:

```shell
error[E0432]: unresolved import `crate::helpers::dotnet::scripting`
  --> src/helpers/dotnet/os/windows.rs:25:29

error[E0425]: cannot find type `UniversalExporter` in this scope
```

The `scripting` module is gated behind the scripting feature (on by default), but `helpers/dotnet/os/linux.rs` imported from it unconditionally. With the feature disabled the module doesn't exist, so the import can't resolve.

Gating the import alone is insufficient: three items from it (`guid_from_provider`, `event_full_name`, `DotNetProviderFlags`) are used by always-compiled code in `OSDotNetEventFactory`, so they must stay reachable without the feature.

Windows additionally gated its `UniversalExporter` import behind `#[cfg(feature = "scripting")]`, even though that type is not feature-gated (only `ScriptedUniversalExporter` is) and is used by always-compiled code in `hook_to_exporter`. With the feature disabled the type became unresolvable.

## Fix
- Moved the three shared symbols (`guid_from_provider`, `event_full_name`, `DotNetProviderFlags`) out of the feature-gated scripting module into a new ungated module `helpers/dotnet/provider`, so they're available without the `scripting` feature. The rhai-only pieces (setter methods, `CustomType` impl) stay gated.
- Updated os/linux.rs and os/windows.rs to import these from `provider` instead of `scripting::*`.
- Removed the erroneous `#[cfg(feature = "scripting")]` gate on the `UniversalExporter` import in `os/windows.rs`.
- Extended the CI "Build (no default features)" step to run on Windows as well as Linux (dropped the `if: runner.os == 'Linux'` guard) so both platforms stay guarded.