### PR TITLE
Bound diagnostic IPC I/O and worker shutdown with timeouts

### DIFF
--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -518,6 +518,11 @@ impl UserEventTracker {
                 }
             }
 
+            /* Reap tracked processes that have exited; dropping the
+             * socket ends their (already-defunct) EventPipe session and
+             * keeps the map from growing across process churn. */
+            pids.retain(|&pid, _| is_process_alive(pid));
+
             if cancelled.load(Ordering::Relaxed) {
                 break;
             }
@@ -725,6 +730,21 @@ impl PerfMapTracker {
                     i += 1;
                 }
             }
+
+            /* Reap tracked processes that have exited: disable and drop
+             * their context, and forget the PID, so state does not grow
+             * across process churn. */
+            {
+                let mut contexts = arc.lock().unwrap();
+                contexts.retain(|proc| {
+                    let alive = is_process_alive(proc.pid);
+                    if !alive {
+                        let _ = proc.disable_perf_map();
+                    }
+                    alive
+                });
+            }
+            pids.retain(|&pid| is_process_alive(pid));
 
             if cancelled.load(Ordering::Relaxed) {
                 break;

--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -54,6 +54,10 @@ const DIAG_SOCKET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(
 /// Timeout for waiting on worker threads during shutdown.
 const WORKER_JOIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// Interval between retry attempts for processes that failed IPC
+/// enablement (e.g. a runtime that was temporarily unreachable).
+const DIAG_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
+
 struct PerfMapContext {
     tmp: OpenAt,
     pid: u32,
@@ -380,44 +384,106 @@ impl UserEventTracker {
         Ok(())
     }
 
+    fn try_enable_events(
+        pid: u32,
+        arc: &Arc<Mutex<UserEventTrackerSettings>>,
+        pids: &mut HashMap<u32, UnixStream>,
+        path_buf: &mut PathBuf,
+        buffer: &mut Vec<u8>) -> bool {
+        let nspid = procfs::ns_pid(path_buf, pid).unwrap_or(pid);
+
+        if let Ok(diag) = PerfMapContext::new(pid, nspid) {
+            if let Some(mut socket) = diag.open_diag_socket() {
+                if let Ok(settings) = arc.lock() {
+                    match Self::enable_events(&mut socket, &settings, buffer) {
+                        Ok(()) => {
+                            info!("Enabled .NET events for process: pid={}", pid);
+                            pids.insert(pid, socket);
+                            return true;
+                        },
+                        Err(err) => {
+                            warn!("Failed to enable .NET events: pid={}, error={}", pid, err);
+                        },
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
     fn worker_thread_proc(
         recv: Receiver<u32>,
         arc: Arc<Mutex<UserEventTrackerSettings>>) {
         let mut pids: HashMap<u32, UnixStream> = HashMap::new();
+        let mut pending: Vec<u32> = Vec::new();
         let mut path_buf = PathBuf::new();
         let mut buffer = Vec::new();
 
         loop {
-            let pid = match recv.recv() {
-                Ok(pid) => { pid },
-                Err(_) => { break; },
+            /* Wait for at least one PID. Block when nothing is pending,
+             * otherwise use a timeout so failed processes get retried.
+             * A timeout yields no PID, which is distinct from receiving
+             * the shutdown sentinel (0). */
+            let first = if pending.is_empty() {
+                match recv.recv() {
+                    Ok(pid) => Some(pid),
+                    Err(_) => break,
+                }
+            } else {
+                match recv.recv_timeout(DIAG_RETRY_INTERVAL) {
+                    Ok(pid) => Some(pid),
+                    Err(mpsc::RecvTimeoutError::Timeout) => None,
+                    Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                }
             };
 
-            if pid == 0 {
+            /* Drain everything immediately available before doing work.
+             * Stop promptly if the shutdown sentinel (0) is seen, even if
+             * other PIDs are queued behind it. */
+            let mut incoming = Vec::new();
+            let mut stop = matches!(first, Some(0));
+
+            if let Some(pid) = first {
+                if pid != 0 {
+                    incoming.push(pid);
+                }
+            }
+
+            while !stop {
+                match recv.try_recv() {
+                    Ok(0) => { stop = true; },
+                    Ok(pid) => { incoming.push(pid); },
+                    Err(_) => { break; },
+                }
+            }
+
+            if stop {
                 break;
             }
 
-            /* Skip if already enabled */
-            if pids.contains_key(&pid) {
-                continue;
-            }
+            /* Process newly discovered PIDs */
+            for pid in incoming {
+                if pids.contains_key(&pid) {
+                    continue;
+                }
 
-            let nspid = procfs::ns_pid(&mut path_buf, pid).unwrap_or(pid);
-
-            if let Ok(diag) = PerfMapContext::new(pid, nspid) {
-                if let Some(mut socket) = diag.open_diag_socket() {
-                    if let Ok(settings) = arc.lock() {
-                        match Self::enable_events(&mut socket, &settings, &mut buffer) {
-                            Ok(()) => {
-                                info!("Enabled .NET events for process: pid={}", pid);
-                                pids.insert(pid, socket);
-                            },
-                            Err(err) => {
-                                warn!("Failed to enable .NET events: pid={}, error={}", pid, err);
-                            },
-                        }
+                if !Self::try_enable_events(
+                    pid, &arc, &mut pids,
+                    &mut path_buf, &mut buffer) {
+                    if !pending.contains(&pid) {
+                        pending.push(pid);
                     }
                 }
+            }
+
+            /* Retry processes that failed earlier */
+            if !pending.is_empty() {
+                pending.retain(|&pid| {
+                    !Self::try_enable_events(
+                        pid, &arc, &mut pids,
+                        &mut path_buf, &mut buffer)
+                });
             }
         }
 
@@ -479,63 +545,122 @@ impl PerfMapTracker {
         }
     }
 
+    fn try_enable_perf_map(
+        pid: u32,
+        arc: &ArcPerfMapContexts,
+        pids: &mut HashSet<u32>,
+        path_buf: &mut PathBuf) -> bool {
+        let nspid = procfs::ns_pid(path_buf, pid).unwrap_or(pid);
+
+        let proc = match PerfMapContext::new(pid, nspid) {
+            Ok(proc) => proc,
+            Err(e) => {
+                warn!("PerfMapTracker: failed to create PerfMapContext: pid={}, nspid={}, error={}", pid, nspid, e);
+                return false;
+            }
+        };
+
+        match proc.has_perf_map_environ() {
+            Ok(true) => {
+                debug!("PerfMapTracker: skipping pid={}, nspid={}, already has perf map env var", pid, nspid);
+                pids.insert(pid);
+                return true;
+            }
+            Ok(false) => { }
+            Err(e) => {
+                warn!("PerfMapTracker: failed to read perf map environ: pid={}, nspid={}, error={}", pid, nspid, e);
+            }
+        }
+
+        /* Always try to disable in case it was left on */
+        let _ = proc.disable_perf_map();
+
+        /* Enable until the thread is done */
+        match proc.enable_perf_map() {
+            Ok(()) => {
+                /* Save context for later */
+                arc.lock().unwrap().push(proc);
+
+                /* Ensure we don't enable it again */
+                pids.insert(pid);
+                true
+            }
+            Err(e) => {
+                warn!("PerfMapTracker: failed to enable perf map: pid={}, nspid={}, error={}", pid, nspid, e);
+                false
+            }
+        }
+    }
+
     fn worker_thread_proc(
         recv: Receiver<u32>,
         arc: ArcPerfMapContexts) {
         let mut pids = HashSet::new();
+        let mut pending: Vec<u32> = Vec::new();
         let mut path_buf = PathBuf::new();
 
         loop {
-            let pid = match recv.recv() {
-                Ok(pid) => { pid },
-                Err(_) => { break; },
+            /* Wait for at least one PID. Block when nothing is pending,
+             * otherwise use a timeout so failed processes get retried.
+             * A timeout yields no PID, which is distinct from receiving
+             * the shutdown sentinel (0). */
+            let first = if pending.is_empty() {
+                match recv.recv() {
+                    Ok(pid) => Some(pid),
+                    Err(_) => break,
+                }
+            } else {
+                match recv.recv_timeout(DIAG_RETRY_INTERVAL) {
+                    Ok(pid) => Some(pid),
+                    Err(mpsc::RecvTimeoutError::Timeout) => None,
+                    Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                }
             };
 
-            if pid == 0 {
+            /* Drain everything immediately available before doing work.
+             * Stop promptly if the shutdown sentinel (0) is seen, even if
+             * other PIDs are queued behind it. */
+            let mut incoming = Vec::new();
+            let mut stop = matches!(first, Some(0));
+
+            if let Some(pid) = first {
+                if pid != 0 {
+                    incoming.push(pid);
+                }
+            }
+
+            while !stop {
+                match recv.try_recv() {
+                    Ok(0) => { stop = true; },
+                    Ok(pid) => { incoming.push(pid); },
+                    Err(_) => { break; },
+                }
+            }
+
+            if stop {
                 break;
             }
 
-            /* Skip if already enabled */
-            if pids.contains(&pid) {
-                continue;
-            }
-
-            let nspid = procfs::ns_pid(&mut path_buf, pid).unwrap_or(pid);
-
-            let proc = match PerfMapContext::new(pid, nspid) {
-                Ok(proc) => proc,
-                Err(e) => {
-                    warn!("PerfMapTracker: failed to create PerfMapContext: pid={}, nspid={}, error={}", pid, nspid, e);
+            /* Process newly discovered PIDs */
+            for pid in incoming {
+                if pids.contains(&pid) {
                     continue;
                 }
-            };
 
-            match proc.has_perf_map_environ() {
-                Ok(true) => {
-                    debug!("PerfMapTracker: skipping pid={}, nspid={}, already has perf map env var", pid, nspid);
-                    continue;
-                }
-                Ok(false) => { }
-                Err(e) => {
-                    warn!("PerfMapTracker: failed to read perf map environ: pid={}, nspid={}, error={}", pid, nspid, e);
+                if !Self::try_enable_perf_map(
+                    pid, &arc, &mut pids, &mut path_buf) {
+                    if !pending.contains(&pid) {
+                        pending.push(pid);
+                    }
                 }
             }
 
-            /* Always try to disable in case it was left on */
-            let _ = proc.disable_perf_map();
-
-            /* Enable until the thread is done */
-            match proc.enable_perf_map() {
-                Ok(()) => {
-                    /* Save context for later */
-                    arc.lock().unwrap().push(proc);
-
-                    /* Ensure we don't enable it again */
-                    pids.insert(pid);
-                }
-                Err(e) => {
-                    warn!("PerfMapTracker: failed to enable perf map: pid={}, nspid={}, error={}", pid, nspid, e);
-                }
+            /* Retry processes that failed earlier */
+            if !pending.is_empty() {
+                pending.retain(|&pid| {
+                    !Self::try_enable_perf_map(
+                        pid, &arc, &mut pids, &mut path_buf)
+                });
             }
         }
 

--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -14,6 +14,7 @@ use std::collections::{HashSet, HashMap};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::sync::mpsc::{self, Sender, Receiver};
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, JoinHandle};
 
 use crate::helpers::dotnet::*;
@@ -57,6 +58,13 @@ const WORKER_JOIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(
 /// Interval between retry attempts for processes that failed IPC
 /// enablement (e.g. a runtime that was temporarily unreachable).
 const DIAG_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Returns true while the process still exists. Used to evict processes
+/// that exited before we could enable IPC, so they are not retried
+/// forever (which would also leak entries on PID reuse).
+fn is_process_alive(pid: u32) -> bool {
+    Path::new(&format!("/proc/{}", pid)).exists()
+}
 
 struct PerfMapContext {
     tmp: OpenAt,
@@ -246,19 +254,26 @@ struct UserEventTrackerSettings {
 struct UserEventTracker {
     send: Sender<u32>,
     worker: Option<JoinHandle<()>>,
+    cancelled: Arc<AtomicBool>,
 }
 
 impl UserEventTracker {
     fn new(settings: Arc<Mutex<UserEventTrackerSettings>>) -> Self {
         let (send, recv) = mpsc::channel();
+        let cancelled = Arc::new(AtomicBool::new(false));
 
-        let worker = thread::spawn(move || {
-            Self::worker_thread_proc(recv, settings);
-        });
+        let worker_cancelled = cancelled.clone();
+        let worker = thread::Builder::new()
+            .name("oc-dotnet-events".into())
+            .spawn(move || {
+                Self::worker_thread_proc(recv, settings, worker_cancelled);
+            })
+            .expect("failed to spawn oc-dotnet-events worker");
 
         Self {
             send,
             worker: Some(worker),
+            cancelled,
         }
     }
 
@@ -414,7 +429,8 @@ impl UserEventTracker {
 
     fn worker_thread_proc(
         recv: Receiver<u32>,
-        arc: Arc<Mutex<UserEventTrackerSettings>>) {
+        arc: Arc<Mutex<UserEventTrackerSettings>>,
+        cancelled: Arc<AtomicBool>) {
         let mut pids: HashMap<u32, UnixStream> = HashMap::new();
         let mut pending: Vec<u32> = Vec::new();
         let mut path_buf = PathBuf::new();
@@ -464,6 +480,10 @@ impl UserEventTracker {
 
             /* Process newly discovered PIDs */
             for pid in incoming {
+                if cancelled.load(Ordering::Relaxed) {
+                    break;
+                }
+
                 if pids.contains_key(&pid) {
                     continue;
                 }
@@ -477,13 +497,29 @@ impl UserEventTracker {
                 }
             }
 
-            /* Retry processes that failed earlier */
-            if !pending.is_empty() {
-                pending.retain(|&pid| {
-                    !Self::try_enable_events(
-                        pid, &arc, &mut pids,
-                        &mut path_buf, &mut buffer)
-                });
+            /* Drop processes that exited before we could enable them so
+             * we don't retry them forever. */
+            pending.retain(|&pid| is_process_alive(pid));
+
+            /* Retry processes that failed earlier, checking for
+             * cancellation between attempts so shutdown is prompt. */
+            let mut i = 0;
+            while i < pending.len() {
+                if cancelled.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                if Self::try_enable_events(
+                    pending[i], &arc, &mut pids,
+                    &mut path_buf, &mut buffer) {
+                    pending.remove(i);
+                } else {
+                    i += 1;
+                }
+            }
+
+            if cancelled.load(Ordering::Relaxed) {
+                break;
             }
         }
 
@@ -504,6 +540,9 @@ impl UserEventTracker {
 
     fn disable(
         &mut self) -> anyhow::Result<()> {
+        /* Signal the worker to stop mid-pass, then wake it. */
+        self.cancelled.store(true, Ordering::Relaxed);
+
         /* Enqueue stop message */
         self.send.send(0)?;
 
@@ -529,19 +568,26 @@ impl UserEventTracker {
 struct PerfMapTracker {
     send: Sender<u32>,
     worker: Option<JoinHandle<()>>,
+    cancelled: Arc<AtomicBool>,
 }
 
 impl PerfMapTracker {
     fn new(arc: ArcPerfMapContexts) -> Self {
         let (send, recv) = mpsc::channel();
+        let cancelled = Arc::new(AtomicBool::new(false));
 
-        let worker = thread::spawn(move || {
-            Self::worker_thread_proc(recv, arc)
-        });
+        let worker_cancelled = cancelled.clone();
+        let worker = thread::Builder::new()
+            .name("oc-dotnet-perfmap".into())
+            .spawn(move || {
+                Self::worker_thread_proc(recv, arc, worker_cancelled)
+            })
+            .expect("failed to spawn oc-dotnet-perfmap worker");
 
         Self {
             send,
             worker: Some(worker),
+            cancelled,
         }
     }
 
@@ -594,7 +640,8 @@ impl PerfMapTracker {
 
     fn worker_thread_proc(
         recv: Receiver<u32>,
-        arc: ArcPerfMapContexts) {
+        arc: ArcPerfMapContexts,
+        cancelled: Arc<AtomicBool>) {
         let mut pids = HashSet::new();
         let mut pending: Vec<u32> = Vec::new();
         let mut path_buf = PathBuf::new();
@@ -643,6 +690,10 @@ impl PerfMapTracker {
 
             /* Process newly discovered PIDs */
             for pid in incoming {
+                if cancelled.load(Ordering::Relaxed) {
+                    break;
+                }
+
                 if pids.contains(&pid) {
                     continue;
                 }
@@ -655,12 +706,28 @@ impl PerfMapTracker {
                 }
             }
 
-            /* Retry processes that failed earlier */
-            if !pending.is_empty() {
-                pending.retain(|&pid| {
-                    !Self::try_enable_perf_map(
-                        pid, &arc, &mut pids, &mut path_buf)
-                });
+            /* Drop processes that exited before we could enable them so
+             * we don't retry them forever. */
+            pending.retain(|&pid| is_process_alive(pid));
+
+            /* Retry processes that failed earlier, checking for
+             * cancellation between attempts so shutdown is prompt. */
+            let mut i = 0;
+            while i < pending.len() {
+                if cancelled.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                if Self::try_enable_perf_map(
+                    pending[i], &arc, &mut pids, &mut path_buf) {
+                    pending.remove(i);
+                } else {
+                    i += 1;
+                }
+            }
+
+            if cancelled.load(Ordering::Relaxed) {
+                break;
             }
         }
 
@@ -684,6 +751,9 @@ impl PerfMapTracker {
 
     fn disable(
         &mut self) -> anyhow::Result<()> {
+        /* Signal the worker to stop mid-pass, then wake it. */
+        self.cancelled.store(true, Ordering::Relaxed);
+
         /* Enqueue stop message */
         self.send.send(0)?;
 

--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -47,6 +47,13 @@ fn is_dotnet_memfd_mapping(filename: &str) -> bool {
     filename.starts_with("/memfd:doublemapper")
 }
 
+/// Conservative timeout for diagnostic socket reads and writes. Prevents
+/// indefinite blocking when a .NET runtime is stopped (e.g. under a debugger).
+const DIAG_SOCKET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Timeout for waiting on worker threads during shutdown.
+const WORKER_JOIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 struct PerfMapContext {
     tmp: OpenAt,
     pid: u32,
@@ -78,6 +85,10 @@ impl PerfMapContext {
                 for path in paths {
                     let path = format!("/proc/{}/root/tmp/{}", self.pid, path);
                     if let Ok(sock) = UnixStream::connect(path) {
+                        /* Bound all reads/writes so a stopped runtime can
+                         * never block a worker thread indefinitely. */
+                        let _ = sock.set_read_timeout(Some(DIAG_SOCKET_TIMEOUT));
+                        let _ = sock.set_write_timeout(Some(DIAG_SOCKET_TIMEOUT));
                         debug!("Opened diagnostic socket: pid={}, nspid={}", self.pid, self.nspid);
                         return Some(sock);
                     }
@@ -430,9 +441,19 @@ impl UserEventTracker {
         /* Enqueue stop message */
         self.send.send(0)?;
 
-        /* Wait for worker to finish */
+        /* Wait for worker to finish, but never block shutdown
+         * indefinitely if it is stuck talking to a wedged runtime. */
         if let Some(worker) = self.worker.take() {
-            let _ = worker.join();
+            let (done_tx, done_rx) = mpsc::channel();
+
+            std::thread::spawn(move || {
+                let _ = worker.join();
+                let _ = done_tx.send(());
+            });
+
+            if done_rx.recv_timeout(WORKER_JOIN_TIMEOUT).is_err() {
+                warn!("oc-dotnet-events worker did not exit within timeout");
+            }
         }
 
         Ok(())
@@ -541,9 +562,19 @@ impl PerfMapTracker {
         /* Enqueue stop message */
         self.send.send(0)?;
 
-        /* Wait for worker to finish */
+        /* Wait for worker to finish, but never block shutdown
+         * indefinitely if it is stuck talking to a wedged runtime. */
         if let Some(worker) = self.worker.take() {
-            let _ = worker.join();
+            let (done_tx, done_rx) = mpsc::channel();
+
+            std::thread::spawn(move || {
+                let _ = worker.join();
+                let _ = done_tx.send(());
+            });
+
+            if done_rx.recv_timeout(WORKER_JOIN_TIMEOUT).is_err() {
+                warn!("oc-dotnet-perfmap worker did not exit within timeout");
+            }
         }
 
         Ok(())


### PR DESCRIPTION
- **Bound diagnostic IPC I/O and worker shutdown with timeouts**
- **Retry diagnostic IPC enablement for unreachable runtimes**
- **Bound worker lifetime and prune dead PIDs from retry list**
- **Reap exited processes from long-lived tracking state**
