### PR TITLE
Bound diagnostic IPC I/O and worker shutdown with timeouts

### DIFF
--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -14,6 +14,7 @@ use std::collections::{HashSet, HashMap};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::sync::mpsc::{self, Sender, Receiver};
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, JoinHandle};
 
 use crate::helpers::dotnet::*;
@@ -47,12 +48,37 @@ fn is_dotnet_memfd_mapping(filename: &str) -> bool {
     filename.starts_with("/memfd:doublemapper")
 }
 
+/* These timeouts form a 2x2 of {steady-state, teardown} x {per-op, aggregate}.
+ * Steady-state ops can legitimately take a few seconds (DIAG_SOCKET_TIMEOUT),
+ * while teardown ops are tiny single writes and should fail fast
+ * (DIAG_DISABLE_TIMEOUT). DIAG_DISABLE_BUDGET caps the teardown loop, and
+ * WORKER_JOIN_TIMEOUT is the outer backstop on disable() itself.
+ *
+ * Invariant: WORKER_JOIN_TIMEOUT should be >= the worst-case time the worker
+ * needs to reach completion after cancellation, i.e. one in-flight op plus
+ * DIAG_DISABLE_BUDGET. With a 5s in-flight op + 3s budget = 8s < 10s, the join
+ * backstop does not fire on a merely-slow-but-healthy teardown. (The events
+ * worker's enable_events can do up to three reads at DIAG_SOCKET_TIMEOUT each,
+ * which can exceed this; the join then detaches+warns, which is harmless.) */
+
 /// Conservative timeout for diagnostic socket reads and writes. Prevents
-/// indefinite blocking when a .NET runtime is stopped (e.g. under a debugger).
+/// indefinite blocking when a .NET runtime is unresponsive.
 const DIAG_SOCKET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Timeout for waiting on worker threads during shutdown.
 const WORKER_JOIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Short timeout for diagnostic socket writes on the teardown path. A
+/// disable request is near-instant against a healthy runtime, so a wedged
+/// one fails fast instead of consuming the full read/write timeout.
+const DIAG_DISABLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Overall budget for best-effort disable of tracked runtimes at shutdown.
+/// Caps total teardown time so a large number of wedged runtimes can't make
+/// shutdown scale with process count. Sized to attempt roughly three teardown
+/// writes (each bounded by DIAG_DISABLE_TIMEOUT) before giving up.
+const DIAG_DISABLE_BUDGET: std::time::Duration =
+    std::time::Duration::from_secs(3 * DIAG_DISABLE_TIMEOUT.as_secs());
 
 struct PerfMapContext {
     tmp: OpenAt,
@@ -180,6 +206,9 @@ impl PerfMapContext {
 
         match self.open_diag_socket() {
             Some(mut sock) => { 
+                /* Teardown writes are near-instant on a healthy runtime;
+                 * fail fast on a wedged one rather than blocking shutdown. */
+                let _ = sock.set_write_timeout(Some(DIAG_DISABLE_TIMEOUT));
                 if let Err(e) = sock.write_all(bytes) {
                     warn!("Failed to write to diagnostic socket: pid={}, nspid={}, error={}", self.pid, self.nspid, e);
                     anyhow::bail!("Failed to write to diagnostic socket: {}", e);
@@ -242,19 +271,32 @@ struct UserEventTrackerSettings {
 struct UserEventTracker {
     send: Sender<u32>,
     worker: Option<JoinHandle<()>>,
+    cancelled: Arc<AtomicBool>,
+    done: Receiver<()>,
 }
 
 impl UserEventTracker {
     fn new(settings: Arc<Mutex<UserEventTrackerSettings>>) -> Self {
         let (send, recv) = mpsc::channel();
+        let (done_tx, done) = mpsc::channel();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let worker_cancelled = cancelled.clone();
 
-        let worker = thread::spawn(move || {
-            Self::worker_thread_proc(recv, settings);
-        });
+        let worker = thread::Builder::new()
+            .name("oc-dotnet-events".into())
+            .spawn(move || {
+                Self::worker_thread_proc(recv, settings, worker_cancelled);
+                /* Signal completion as the last act so disable() can wait
+                 * with a timeout without spawning a helper thread. */
+                let _ = done_tx.send(());
+            })
+            .expect("failed to spawn oc-dotnet-events worker");
 
         Self {
             send,
             worker: Some(worker),
+            cancelled,
+            done,
         }
     }
 
@@ -382,7 +424,8 @@ impl UserEventTracker {
 
     fn worker_thread_proc(
         recv: Receiver<u32>,
-        arc: Arc<Mutex<UserEventTrackerSettings>>) {
+        arc: Arc<Mutex<UserEventTrackerSettings>>,
+        cancelled: Arc<AtomicBool>) {
         let mut pids: HashMap<u32, UnixStream> = HashMap::new();
         let mut path_buf = PathBuf::new();
         let mut buffer = Vec::new();
@@ -393,7 +436,9 @@ impl UserEventTracker {
                 Err(_) => { break; },
             };
 
-            if pid == 0 {
+            /* Stop on the shutdown sentinel, or once cancelled so any
+             * PIDs already queued behind it don't delay shutdown. */
+            if pid == 0 || cancelled.load(Ordering::Relaxed) {
                 break;
             }
 
@@ -438,20 +483,20 @@ impl UserEventTracker {
 
     fn disable(
         &mut self) -> anyhow::Result<()> {
+        /* Ask the worker to stop taking new work, then wake it. */
+        self.cancelled.store(true, Ordering::Relaxed);
+
         /* Enqueue stop message */
         self.send.send(0)?;
 
-        /* Wait for worker to finish, but never block shutdown
-         * indefinitely if it is stuck talking to a wedged runtime. */
+        /* Wait for the worker to finish, but never block shutdown
+         * indefinitely if it is wedged in an un-interruptible syscall.
+         * The worker signals completion on the done channel; on timeout we
+         * detach (drop the handle without joining) as a backstop. */
         if let Some(worker) = self.worker.take() {
-            let (done_tx, done_rx) = mpsc::channel();
-
-            std::thread::spawn(move || {
+            if self.done.recv_timeout(WORKER_JOIN_TIMEOUT).is_ok() {
                 let _ = worker.join();
-                let _ = done_tx.send(());
-            });
-
-            if done_rx.recv_timeout(WORKER_JOIN_TIMEOUT).is_err() {
+            } else {
                 warn!("oc-dotnet-events worker did not exit within timeout");
             }
         }
@@ -463,25 +508,39 @@ impl UserEventTracker {
 struct PerfMapTracker {
     send: Sender<u32>,
     worker: Option<JoinHandle<()>>,
+    cancelled: Arc<AtomicBool>,
+    done: Receiver<()>,
 }
 
 impl PerfMapTracker {
     fn new(arc: ArcPerfMapContexts) -> Self {
         let (send, recv) = mpsc::channel();
+        let (done_tx, done) = mpsc::channel();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let worker_cancelled = cancelled.clone();
 
-        let worker = thread::spawn(move || {
-            Self::worker_thread_proc(recv, arc)
-        });
+        let worker = thread::Builder::new()
+            .name("oc-dotnet-perfmap".into())
+            .spawn(move || {
+                Self::worker_thread_proc(recv, arc, worker_cancelled);
+                /* Signal completion as the last act so disable() can wait
+                 * with a timeout without spawning a helper thread. */
+                let _ = done_tx.send(());
+            })
+            .expect("failed to spawn oc-dotnet-perfmap worker");
 
         Self {
             send,
             worker: Some(worker),
+            cancelled,
+            done,
         }
     }
 
     fn worker_thread_proc(
         recv: Receiver<u32>,
-        arc: ArcPerfMapContexts) {
+        arc: ArcPerfMapContexts,
+        cancelled: Arc<AtomicBool>) {
         let mut pids = HashSet::new();
         let mut path_buf = PathBuf::new();
 
@@ -491,7 +550,9 @@ impl PerfMapTracker {
                 Err(_) => { break; },
             };
 
-            if pid == 0 {
+            /* Stop on the shutdown sentinel, or once cancelled so any
+             * PIDs already queued behind it don't delay shutdown. */
+            if pid == 0 || cancelled.load(Ordering::Relaxed) {
                 break;
             }
 
@@ -539,10 +600,25 @@ impl PerfMapTracker {
             }
         }
 
-        /* Thread is done, disable in-case caller forgets */
-        for proc in arc.lock().unwrap().iter() {
+        /* Thread is done: best-effort disable so still-running runtimes stop
+         * emitting perf maps. Drain the contexts out from under the lock so a
+         * slow disable never holds it across blocking I/O (which would stall
+         * remove_perf_maps at exporter drop), and cap the total time so a
+         * large number of wedged runtimes can't make shutdown scale with
+         * process count. The contexts are put back so the file cleanup in
+         * remove_perf_maps can still run. */
+        let contexts = std::mem::take(&mut *arc.lock().unwrap());
+
+        let deadline = std::time::Instant::now() + DIAG_DISABLE_BUDGET;
+        for proc in &contexts {
+            if std::time::Instant::now() >= deadline {
+                warn!("oc-dotnet-perfmap: disable budget exhausted, some runtimes left enabled");
+                break;
+            }
             let _ = proc.disable_perf_map();
         }
+
+        *arc.lock().unwrap() = contexts;
     }
 
     fn track(
@@ -559,20 +635,20 @@ impl PerfMapTracker {
 
     fn disable(
         &mut self) -> anyhow::Result<()> {
+        /* Ask the worker to stop taking new work, then wake it. */
+        self.cancelled.store(true, Ordering::Relaxed);
+
         /* Enqueue stop message */
         self.send.send(0)?;
 
-        /* Wait for worker to finish, but never block shutdown
-         * indefinitely if it is stuck talking to a wedged runtime. */
+        /* Wait for the worker to finish, but never block shutdown
+         * indefinitely if it is wedged in an un-interruptible syscall.
+         * The worker signals completion on the done channel; on timeout we
+         * detach (drop the handle without joining) as a backstop. */
         if let Some(worker) = self.worker.take() {
-            let (done_tx, done_rx) = mpsc::channel();
-
-            std::thread::spawn(move || {
+            if self.done.recv_timeout(WORKER_JOIN_TIMEOUT).is_ok() {
                 let _ = worker.join();
-                let _ = done_tx.send(());
-            });
-
-            if done_rx.recv_timeout(WORKER_JOIN_TIMEOUT).is_err() {
+            } else {
                 warn!("oc-dotnet-perfmap worker did not exit within timeout");
             }
         }

--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -63,10 +63,12 @@ const DIAG_SOCKET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(
 /// one fails fast instead of consuming the full read/write timeout.
 const DIAG_DISABLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
-/// Default budget for the perf-map disable loop at shutdown. Overridable via
+/// Default budget for the perf-map disable loop at shutdown. Sized to favor
+/// disabling as many runtimes as possible (e.g. hundreds of processes) while
+/// still bounding shutdown when a runtime is unresponsive. Overridable via
 /// DotNetHelper::with_cleanup_timeout (record-trace: --dotnet-cleanup-timeout)
 /// to trade teardown time for a cleaner final state.
-const DEFAULT_DOTNET_CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const DEFAULT_DOTNET_CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Scheduling/channel slack on top of the bounded in-flight I/O.
 const DIAG_DRAIN_MARGIN: std::time::Duration = std::time::Duration::from_secs(1);
@@ -182,11 +184,11 @@ impl PerfMapContext {
                 let mut result = [0; 24];
 
                 if let Err(e) = sock.write_all(bytes) {
-                    warn!("Failed to write to diagnostic socket: pid={}, nspid={}, error={}", self.pid, self.nspid, e);
+                    warn!("Failed to write to diagnostic socket: pid={}, nspid={}, timeout={:?}, error={}", self.pid, self.nspid, DIAG_SOCKET_TIMEOUT, e);
                     anyhow::bail!("Failed to write to diagnostic socket: {}", e);
                 }
                 if let Err(e) = sock.read_exact(&mut result) {
-                    warn!("Failed to read diagnostic socket response: pid={}, nspid={}, error={}", self.pid, self.nspid, e);
+                    warn!("Failed to read diagnostic socket response: pid={}, nspid={}, timeout={:?}, error={}", self.pid, self.nspid, DIAG_SOCKET_TIMEOUT, e);
                     anyhow::bail!("Failed to read diagnostic socket response: {}", e);
                 }
 
@@ -213,7 +215,7 @@ impl PerfMapContext {
                  * fail fast on a wedged one rather than blocking shutdown. */
                 let _ = sock.set_write_timeout(Some(DIAG_DISABLE_TIMEOUT));
                 if let Err(e) = sock.write_all(bytes) {
-                    warn!("Failed to write to diagnostic socket: pid={}, nspid={}, error={}", self.pid, self.nspid, e);
+                    warn!("Failed to write to diagnostic socket: pid={}, nspid={}, timeout={:?}, error={}", self.pid, self.nspid, DIAG_DISABLE_TIMEOUT, e);
                     anyhow::bail!("Failed to write to diagnostic socket: {}", e);
                 }
                 Ok(())
@@ -497,10 +499,11 @@ impl UserEventTracker {
          * The worker signals completion on the done channel; on timeout we
          * detach (drop the handle without joining) as a backstop. */
         if let Some(worker) = self.worker.take() {
-            if self.done.recv_timeout(dotnet_worker_join_timeout(std::time::Duration::ZERO)).is_ok() {
+            let join_timeout = dotnet_worker_join_timeout(std::time::Duration::ZERO);
+            if self.done.recv_timeout(join_timeout).is_ok() {
                 let _ = worker.join();
             } else {
-                warn!("oc-dotnet-events worker did not exit within timeout");
+                warn!("oc-dotnet-events worker did not exit within timeout={:?}", join_timeout);
             }
         }
 
@@ -622,7 +625,7 @@ impl PerfMapTracker {
             .unwrap_or_else(std::time::Instant::now);
         for proc in &contexts {
             if std::time::Instant::now() >= deadline {
-                warn!("oc-dotnet-perfmap: disable budget exhausted, some runtimes left enabled");
+                warn!("oc-dotnet-perfmap: disable budget exhausted, some runtimes left enabled: budget={:?}", cleanup_timeout);
                 break;
             }
             let _ = proc.disable_perf_map();
@@ -659,7 +662,7 @@ impl PerfMapTracker {
             if self.done.recv_timeout(self.join_timeout).is_ok() {
                 let _ = worker.join();
             } else {
-                warn!("oc-dotnet-perfmap worker did not exit within timeout");
+                warn!("oc-dotnet-perfmap worker did not exit within timeout={:?}", self.join_timeout);
             }
         }
 

--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -48,37 +48,40 @@ fn is_dotnet_memfd_mapping(filename: &str) -> bool {
     filename.starts_with("/memfd:doublemapper")
 }
 
-/* These timeouts form a 2x2 of {steady-state, teardown} x {per-op, aggregate}.
- * Steady-state ops can legitimately take a few seconds (DIAG_SOCKET_TIMEOUT),
- * while teardown ops are tiny single writes and should fail fast
- * (DIAG_DISABLE_TIMEOUT). DIAG_DISABLE_BUDGET caps the teardown loop, and
- * WORKER_JOIN_TIMEOUT is the outer backstop on disable() itself.
- *
- * Invariant: WORKER_JOIN_TIMEOUT should be >= the worst-case time the worker
- * needs to reach completion after cancellation, i.e. one in-flight op plus
- * DIAG_DISABLE_BUDGET. With a 5s in-flight op + 3s budget = 8s < 10s, the join
- * backstop does not fire on a merely-slow-but-healthy teardown. (The events
- * worker's enable_events can do up to three reads at DIAG_SOCKET_TIMEOUT each,
- * which can exceed this; the join then detaches+warns, which is harmless.) */
+/* Two kinds of timeout. Per-op timeouts bound a single socket exchange:
+ * DIAG_SOCKET_TIMEOUT for a read/write, DIAG_DISABLE_TIMEOUT for the tiny
+ * teardown write. The join timeout (dotnet_worker_join_timeout) bounds how long
+ * disable() waits for a cancelled worker to drain before detaching it, so a
+ * wedged runtime can never hang shutdown. */
 
 /// Conservative timeout for diagnostic socket reads and writes. Prevents
 /// indefinite blocking when a .NET runtime is unresponsive.
 const DIAG_SOCKET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-
-/// Timeout for waiting on worker threads during shutdown.
-const WORKER_JOIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Short timeout for diagnostic socket writes on the teardown path. A
 /// disable request is near-instant against a healthy runtime, so a wedged
 /// one fails fast instead of consuming the full read/write timeout.
 const DIAG_DISABLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
-/// Overall budget for best-effort disable of tracked runtimes at shutdown.
-/// Caps total teardown time so a large number of wedged runtimes can't make
-/// shutdown scale with process count. Sized to attempt roughly three teardown
-/// writes (each bounded by DIAG_DISABLE_TIMEOUT) before giving up.
-const DIAG_DISABLE_BUDGET: std::time::Duration =
-    std::time::Duration::from_secs(3 * DIAG_DISABLE_TIMEOUT.as_secs());
+/// Default budget for the perf-map disable loop at shutdown. Overridable via
+/// DotNetHelper::with_cleanup_timeout (record-trace: --dotnet-cleanup-timeout)
+/// to trade teardown time for a cleaner final state.
+const DEFAULT_DOTNET_CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Scheduling/channel slack on top of the bounded in-flight I/O.
+const DIAG_DRAIN_MARGIN: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Join backstop shared by both .NET IPC workers: the teardown_budget (the
+/// perf-map disable loop; zero for the events worker, which has no such loop)
+/// plus the worst-case in-flight handshake. Cancellation is only polled at the
+/// top of each worker loop, so disable() can land mid-handshake; the largest is
+/// the events enable - two writes + two reads, each bounded by
+/// DIAG_SOCKET_TIMEOUT. saturating_add guards against an extreme budget.
+fn dotnet_worker_join_timeout(teardown_budget: std::time::Duration) -> std::time::Duration {
+    teardown_budget
+        .saturating_add(4 * DIAG_SOCKET_TIMEOUT)
+        .saturating_add(DIAG_DRAIN_MARGIN)
+}
 
 struct PerfMapContext {
     tmp: OpenAt,
@@ -494,7 +497,7 @@ impl UserEventTracker {
          * The worker signals completion on the done channel; on timeout we
          * detach (drop the handle without joining) as a backstop. */
         if let Some(worker) = self.worker.take() {
-            if self.done.recv_timeout(WORKER_JOIN_TIMEOUT).is_ok() {
+            if self.done.recv_timeout(dotnet_worker_join_timeout(std::time::Duration::ZERO)).is_ok() {
                 let _ = worker.join();
             } else {
                 warn!("oc-dotnet-events worker did not exit within timeout");
@@ -510,10 +513,13 @@ struct PerfMapTracker {
     worker: Option<JoinHandle<()>>,
     cancelled: Arc<AtomicBool>,
     done: Receiver<()>,
+    join_timeout: std::time::Duration,
 }
 
 impl PerfMapTracker {
-    fn new(arc: ArcPerfMapContexts) -> Self {
+    fn new(
+        arc: ArcPerfMapContexts,
+        cleanup_timeout: std::time::Duration) -> Self {
         let (send, recv) = mpsc::channel();
         let (done_tx, done) = mpsc::channel();
         let cancelled = Arc::new(AtomicBool::new(false));
@@ -522,7 +528,7 @@ impl PerfMapTracker {
         let worker = thread::Builder::new()
             .name("oc-dotnet-perfmap".into())
             .spawn(move || {
-                Self::worker_thread_proc(recv, arc, worker_cancelled);
+                Self::worker_thread_proc(recv, arc, worker_cancelled, cleanup_timeout);
                 /* Signal completion as the last act so disable() can wait
                  * with a timeout without spawning a helper thread. */
                 let _ = done_tx.send(());
@@ -534,13 +540,15 @@ impl PerfMapTracker {
             worker: Some(worker),
             cancelled,
             done,
+            join_timeout: dotnet_worker_join_timeout(cleanup_timeout),
         }
     }
 
     fn worker_thread_proc(
         recv: Receiver<u32>,
         arc: ArcPerfMapContexts,
-        cancelled: Arc<AtomicBool>) {
+        cancelled: Arc<AtomicBool>,
+        cleanup_timeout: std::time::Duration) {
         let mut pids = HashSet::new();
         let mut path_buf = PathBuf::new();
 
@@ -609,7 +617,9 @@ impl PerfMapTracker {
          * remove_perf_maps can still run. */
         let contexts = std::mem::take(&mut *arc.lock().unwrap());
 
-        let deadline = std::time::Instant::now() + DIAG_DISABLE_BUDGET;
+        let deadline = std::time::Instant::now()
+            .checked_add(cleanup_timeout)
+            .unwrap_or_else(std::time::Instant::now);
         for proc in &contexts {
             if std::time::Instant::now() >= deadline {
                 warn!("oc-dotnet-perfmap: disable budget exhausted, some runtimes left enabled");
@@ -646,7 +656,7 @@ impl PerfMapTracker {
          * The worker signals completion on the done channel; on timeout we
          * detach (drop the handle without joining) as a backstop. */
         if let Some(worker) = self.worker.take() {
-            if self.done.recv_timeout(WORKER_JOIN_TIMEOUT).is_ok() {
+            if self.done.recv_timeout(self.join_timeout).is_ok() {
                 let _ = worker.join();
             } else {
                 warn!("oc-dotnet-perfmap worker did not exit within timeout");
@@ -662,6 +672,7 @@ type ArcPerfMapContexts = Arc<Mutex<Vec<PerfMapContext>>>;
 pub(crate) struct OSDotNetHelper {
     perf_maps: bool,
     perf_map_procs: Option<ArcPerfMapContexts>,
+    cleanup_timeout: std::time::Duration,
 }
 
 impl OSDotNetHelper {
@@ -669,12 +680,15 @@ impl OSDotNetHelper {
         Self {
             perf_maps: false,
             perf_map_procs: None,
+            cleanup_timeout: DEFAULT_DOTNET_CLEANUP_TIMEOUT,
         }
     }
 }
 
 pub trait DotNetHelperLinuxExt {
     fn with_perf_maps(self) -> Self;
+
+    fn with_cleanup_timeout(self, timeout: std::time::Duration) -> Self;
 
     fn remove_perf_maps(&mut self);
 
@@ -688,6 +702,11 @@ impl DotNetHelperLinuxExt for DotNetHelper {
             Arc::new(
                 Mutex::new(
                     Vec::new())));
+        self
+    }
+
+    fn with_cleanup_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.os.cleanup_timeout = timeout;
         self
     }
 
@@ -1548,6 +1567,10 @@ impl UniversalDotNetHelperOSHooks for DotNetHelper {
         self.with_perf_maps()
     }
 
+    fn os_with_cleanup_timeout(self, timeout: std::time::Duration) -> Self {
+        self.with_cleanup_timeout(timeout)
+    }
+
     fn os_cleanup_dynamic_symbols(&mut self) {
         self.remove_perf_maps();
     }
@@ -1558,6 +1581,7 @@ impl DotNetHelp for RingBufSessionBuilder {
         mut self,
         helper: &mut DotNetHelper) -> Self {
         let perf_maps = helper.os.perf_maps;
+        let cleanup_timeout = helper.os.cleanup_timeout;
         let perf_maps_procs = match helper.os.perf_map_procs.as_ref() {
             Some(arc) => { Some(arc.clone()) },
             None => { None },
@@ -1589,7 +1613,7 @@ impl DotNetHelp for RingBufSessionBuilder {
                     let filename = fmt.get_field_ref_unchecked("filename[]");
 
                     /* SAFETY: We always have this for perf_maps_procs */
-                    let tracker = PerfMapTracker::new(perf_maps_procs.unwrap());
+                    let tracker = PerfMapTracker::new(perf_maps_procs.unwrap(), cleanup_timeout);
                     let perfmap = Writable::new(tracker);
                     let perfmap_close = perfmap.clone();
 

--- a/one_collect/src/helpers/dotnet/os/linux.rs
+++ b/one_collect/src/helpers/dotnet/os/linux.rs
@@ -47,6 +47,13 @@ fn is_dotnet_memfd_mapping(filename: &str) -> bool {
     filename.starts_with("/memfd:doublemapper")
 }
 
+/// Conservative timeout for diagnostic socket reads and writes. Prevents
+/// indefinite blocking when a .NET runtime is stopped (e.g. under a debugger).
+const DIAG_SOCKET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Timeout for waiting on worker threads during shutdown.
+const WORKER_JOIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 struct PerfMapContext {
     tmp: OpenAt,
     pid: u32,
@@ -78,6 +85,10 @@ impl PerfMapContext {
                 for path in paths {
                     let path = format!("/proc/{}/root/tmp/{}", self.pid, path);
                     if let Ok(sock) = UnixStream::connect(path) {
+                        /* Bound all reads/writes so a stopped runtime can
+                         * never block a worker thread indefinitely. */
+                        let _ = sock.set_read_timeout(Some(DIAG_SOCKET_TIMEOUT));
+                        let _ = sock.set_write_timeout(Some(DIAG_SOCKET_TIMEOUT));
                         debug!("Opened diagnostic socket: pid={}, nspid={}", self.pid, self.nspid);
                         return Some(sock);
                     }
@@ -430,9 +441,19 @@ impl UserEventTracker {
         /* Enqueue stop message */
         self.send.send(0)?;
 
-        /* Wait for worker to finish */
+        /* Wait for worker to finish, but never block shutdown
+         * indefinitely if it is stuck talking to a wedged runtime. */
         if let Some(worker) = self.worker.take() {
-            let _ = worker.join();
+            let (done_tx, done_rx) = mpsc::channel();
+
+            std::thread::spawn(move || {
+                let _ = worker.join();
+                let _ = done_tx.send(());
+            });
+
+            if done_rx.recv_timeout(WORKER_JOIN_TIMEOUT).is_err() {
+                warn!("oc-dotnet-events worker did not exit within timeout");
+            }
         }
 
         Ok(())
@@ -541,9 +562,19 @@ impl PerfMapTracker {
         /* Enqueue stop message */
         self.send.send(0)?;
 
-        /* Wait for worker to finish */
+        /* Wait for worker to finish, but never block shutdown
+         * indefinitely if it is stuck talking to a wedged runtime. */
         if let Some(worker) = self.worker.take() {
-            let _ = worker.join();
+            let (done_tx, done_rx) = mpsc::channel();
+
+            std::thread::spawn(move || {
+                let _ = worker.join();
+                let _ = done_tx.send(());
+            });
+
+            if done_rx.recv_timeout(WORKER_JOIN_TIMEOUT).is_err() {
+                warn!("oc-dotnet-perfmap worker did not exit within timeout");
+            }
         }
 
         Ok(())

--- a/one_collect/src/helpers/dotnet/os/windows.rs
+++ b/one_collect/src/helpers/dotnet/os/windows.rs
@@ -382,6 +382,11 @@ impl UniversalDotNetHelperOSHooks for DotNetHelper {
         self.with_jit_symbols()
     }
 
+    fn os_with_cleanup_timeout(self, _timeout: std::time::Duration) -> Self {
+        /* The cleanup budget only applies to the Linux perf-map teardown. */
+        self
+    }
+
     fn os_cleanup_dynamic_symbols(&mut self) {
         /* Placeholder */
     }

--- a/one_collect/src/helpers/dotnet/universal.rs
+++ b/one_collect/src/helpers/dotnet/universal.rs
@@ -19,6 +19,8 @@ impl Default for UniversalDotNetHelper {
 pub(crate) trait UniversalDotNetHelperOSHooks {
     fn os_with_dynamic_symbols(self) -> Self;
 
+    fn os_with_cleanup_timeout(self, timeout: std::time::Duration) -> Self;
+
     fn os_cleanup_dynamic_symbols(&mut self);
 }
 
@@ -31,6 +33,18 @@ impl UniversalDotNetHelper {
 
     pub fn with_dynamic_symbols(mut self) -> Self {
         self.helper = self.helper.os_with_dynamic_symbols();
+
+        self
+    }
+
+    /// Overrides the .NET cleanup budget used during shutdown teardown. Larger
+    /// values favor a cleaner final state (more runtimes disabled) at the cost
+    /// of longer teardown when runtimes are unresponsive. None keeps the
+    /// built-in default.
+    pub fn with_cleanup_timeout(mut self, timeout: Option<std::time::Duration>) -> Self {
+        if let Some(timeout) = timeout {
+            self.helper = self.helper.os_with_cleanup_timeout(timeout);
+        }
 
         self
     }

--- a/record-trace/engine/src/commandline.rs
+++ b/record-trace/engine/src/commandline.rs
@@ -49,7 +49,7 @@ struct Args {
     #[arg(long = "cpu", help = "Capture data for the specified CPU.  Multiple cpus can be specified, one per usage of --cpu")]
     target_cpus: Option<Vec<u16>>,
 
-    #[arg(long = "dotnet-cleanup-timeout", value_parser = clap::value_parser!(u64).range(0..=86_400), help = "Total seconds budgeted to disable tracked .NET runtimes at shutdown. Higher values favor a cleaner final state (more runtimes disabled) at the cost of longer teardown when runtimes are unresponsive. Defaults to 10.")]
+    #[arg(long = "dotnet-cleanup-timeout", value_parser = clap::value_parser!(u64).range(0..=86_400), help = "Total seconds budgeted to disable tracked .NET runtimes at shutdown. Higher values favor a cleaner final state (more runtimes disabled) at the cost of longer teardown when runtimes are unresponsive. Defaults to 60.")]
     dotnet_cleanup_timeout: Option<u64>,
 
     #[arg(long, help = "Script snippet to run to enable complex configurations")]

--- a/record-trace/engine/src/commandline.rs
+++ b/record-trace/engine/src/commandline.rs
@@ -49,6 +49,9 @@ struct Args {
     #[arg(long = "cpu", help = "Capture data for the specified CPU.  Multiple cpus can be specified, one per usage of --cpu")]
     target_cpus: Option<Vec<u16>>,
 
+    #[arg(long = "dotnet-cleanup-timeout", value_parser = clap::value_parser!(u64).range(0..=86_400), help = "Total seconds budgeted to disable tracked .NET runtimes at shutdown. Higher values favor a cleaner final state (more runtimes disabled) at the cost of longer teardown when runtimes are unresponsive. Defaults to 10.")]
+    dotnet_cleanup_timeout: Option<u64>,
+
     #[arg(long, help = "Script snippet to run to enable complex configurations")]
     script: Option<String>,
 
@@ -113,6 +116,7 @@ pub struct RecordArgs {
     max_memory_bytes: Option<u64>,
     target_pids: Option<Vec<i32>>,
     target_cpus: Option<Vec<u16>>,
+    dotnet_cleanup_timeout: Option<Duration>,
     script: Option<String>,
     log_filter: Option<String>,
     log_path: Option<String>,
@@ -172,6 +176,7 @@ impl RecordArgs {
             max_memory_bytes: command_args.max_memory.map(|mb| mb.saturating_mul(1024 * 1024)),
             target_pids: command_args.target_pids,
             target_cpus: command_args.target_cpus,
+            dotnet_cleanup_timeout: command_args.dotnet_cleanup_timeout.map(Duration::from_secs),
             script,
             log_filter: command_args.log_filter,
             log_path: command_args.log_path,
@@ -237,6 +242,10 @@ impl RecordArgs {
 
     pub (crate) fn target_cpus(&self) -> &Option<Vec<u16>> {
         &self.target_cpus
+    }
+
+    pub (crate) fn dotnet_cleanup_timeout(&self) -> Option<Duration> {
+        self.dotnet_cleanup_timeout
     }
 
     pub (crate) fn script(&self) -> &Option<String> {

--- a/record-trace/engine/src/recorder.rs
+++ b/record-trace/engine/src/recorder.rs
@@ -277,7 +277,8 @@ impl Recorder {
         }
 
         let dotnet = UniversalDotNetHelper::default()
-            .with_dynamic_symbols();
+            .with_dynamic_symbols()
+            .with_cleanup_timeout(self.args.dotnet_cleanup_timeout());
 
         let universal = match self.args.script() {
             Some(script) => {


### PR DESCRIPTION
A machine-wide trace discovers every .NET process and, per process, opens a diagnostic-IPC unix socket under `/proc/<pid>/root/tmp/...` to enable EventPipe events and perf-maps. This runs on single worker threads doing *blocking* `read_exact` / `write_all` on the socket with no timeout. If any discovered runtime is unresponsive that blocking I/O never returns. The worker wedges on the first such process, every later process is starved behind it, and shutdown (`PerfSession` drop -> `disable()` -> `worker.join()`) blocks **forever**. The whole trace session locks up.

## What this PR does

This PR now has two commits in `one_collect/src/helpers/dotnet/os/linux.rs`:

- **Commit 1: time-bound diagnostic IPC and shutdown wait.**
  - Set 5s read/write timeout on diagnostic socket I/O (`DIAG_SOCKET_TIMEOUT`).
  - Bound tracker shutdown wait to 10s (`WORKER_JOIN_TIMEOUT`) so `disable()`
    cannot wait forever.
- **Commit 2: make shutdown bounded even with multiple wedged runtimes.**
  - Add a cancellation flag so workers stop accepting queued work during
    teardown.
  - Replace helper-thread join wait with worker completion channel signaling
    (cheaper than spawning a helper thread per disable).
  - Use short teardown write timeout (`DIAG_DISABLE_TIMEOUT`, 1s) for
    `disable_perf_map`.
  - In perf-map tail cleanup, move contexts out of the mutex, disable under a
    total budget (`DIAG_DISABLE_BUDGET`, 3s), then restore contexts so
    `remove_perf_maps` can still remove files.
  - The timeouts form a 2x2 of steady-state vs teardown and per-op vs
    aggregate limits, with `WORKER_JOIN_TIMEOUT` acting as the outer backstop.

## Behavior change

- A stopped/unresponsive runtime degrades instead of hanging the trace: enablement fails after <=5s and the worker can move on.
- `disable()` remains time-bounded (<=10s wait per tracker), while workers are also prevented from consuming unbounded queued work during teardown.
- Perf-map disable tail cleanup no longer holds the shared perf-map mutex across blocking socket I/O.

## Known limitations (intentionally out of scope here)

- `UnixStream::connect` is still unbounded; only post-connect I/O is timed.
- Process tracking keys on raw PID with no per-process eviction, so a re-used PID is mishandled (#303).
- The worker is still **serial and single-shot**. A stopped process still costs the worker up to ~5s per blocking op before it moves on, and a runtime that was only *temporarily* unreachable gets a single attempt and is dropped on failure. Retrying unreachable runtimes is a possible follow-up.

Fixes https://github.com/microsoft/one-collect/issues/301