### PR TITLE
Add query_stats function and TraceStats struct for ETW session metrics

### DIFF
--- a/one_collect/src/etw/abi.rs
+++ b/one_collect/src/etw/abi.rs
@@ -883,16 +883,16 @@ pub(super) struct TraceStatsRaw {
 pub(super) fn query_stats(handle: u64) -> anyhow::Result<TraceStatsRaw> {
     let mut properties = EVENT_TRACE_PROPERTIES::for_control();
 
-    unsafe {
-        let result = ControlTraceW(
+    let result = unsafe {
+        ControlTraceW(
             handle,
             std::ptr::null(),
             &mut properties,
-            EVENT_TRACE_CONTROL_QUERY);
+            EVENT_TRACE_CONTROL_QUERY)
+    };
 
-        if result != 0 {
-            anyhow::bail!("ControlTraceW query failed with {}", result);
-        }
+    if result != 0 {
+        anyhow::bail!("ControlTraceW query failed with {}", result);
     }
 
     Ok(TraceStatsRaw {

--- a/one_collect/src/etw/abi.rs
+++ b/one_collect/src/etw/abi.rs
@@ -873,7 +873,7 @@ impl TraceEnable {
     }
 }
 
-pub(super) fn query_stats(handle: u64) -> anyhow::Result<super::TraceStats> {
+pub(super) fn query_stats(handle: u64) -> anyhow::Result<super::SessionStats> {
     let mut properties = EVENT_TRACE_PROPERTIES::for_control();
 
     let result = unsafe {
@@ -888,7 +888,7 @@ pub(super) fn query_stats(handle: u64) -> anyhow::Result<super::TraceStats> {
         anyhow::bail!("ControlTraceW query failed with {}", result);
     }
 
-    Ok(super::TraceStats {
+    Ok(super::SessionStats {
         events_lost: properties.EventsLost,
         real_time_buffers_lost: properties.RealTimeBuffersLost,
         log_buffers_lost: properties.LogBuffersLost,

--- a/one_collect/src/etw/abi.rs
+++ b/one_collect/src/etw/abi.rs
@@ -519,6 +519,7 @@ impl Default for ENABLE_TRACE_PARAMETERS {
 pub(super) use windows_sys::Win32::System::Diagnostics::Etw::{
     EVENT_HEADER_EXTENDED_DATA_ITEM,
     EVENT_RECORD,
+    EVENT_TRACE_CONTROL_QUERY,
 };
 
 /// Extension trait providing the few ergonomic accessors the rest of the
@@ -870,6 +871,36 @@ impl TraceEnable {
 
         Ok(())
     }
+}
+
+pub(super) struct TraceStatsRaw {
+    pub events_lost: u32,
+    pub real_time_buffers_lost: u32,
+    pub log_buffers_lost: u32,
+    pub buffers_written: u32,
+}
+
+pub(super) fn query_stats(handle: u64) -> anyhow::Result<TraceStatsRaw> {
+    let mut properties = EVENT_TRACE_PROPERTIES::for_control();
+
+    unsafe {
+        let result = ControlTraceW(
+            handle,
+            std::ptr::null(),
+            &mut properties,
+            EVENT_TRACE_CONTROL_QUERY);
+
+        if result != 0 {
+            anyhow::bail!("ControlTraceW query failed with {}", result);
+        }
+    }
+
+    Ok(TraceStatsRaw {
+        events_lost: properties.EventsLost,
+        real_time_buffers_lost: properties.RealTimeBuffersLost,
+        log_buffers_lost: properties.LogBuffersLost,
+        buffers_written: properties.BuffersWritten,
+    })
 }
 
 pub(crate) fn flush_trace(handle: u64) {

--- a/one_collect/src/etw/abi.rs
+++ b/one_collect/src/etw/abi.rs
@@ -873,14 +873,7 @@ impl TraceEnable {
     }
 }
 
-pub(super) struct TraceStatsRaw {
-    pub events_lost: u32,
-    pub real_time_buffers_lost: u32,
-    pub log_buffers_lost: u32,
-    pub buffers_written: u32,
-}
-
-pub(super) fn query_stats(handle: u64) -> anyhow::Result<TraceStatsRaw> {
+pub(super) fn query_stats(handle: u64) -> anyhow::Result<super::TraceStats> {
     let mut properties = EVENT_TRACE_PROPERTIES::for_control();
 
     let result = unsafe {
@@ -895,7 +888,7 @@ pub(super) fn query_stats(handle: u64) -> anyhow::Result<TraceStatsRaw> {
         anyhow::bail!("ControlTraceW query failed with {}", result);
     }
 
-    Ok(TraceStatsRaw {
+    Ok(super::TraceStats {
         events_lost: properties.EventsLost,
         real_time_buffers_lost: properties.RealTimeBuffersLost,
         log_buffers_lost: properties.LogBuffersLost,

--- a/one_collect/src/etw/mod.rs
+++ b/one_collect/src/etw/mod.rs
@@ -52,26 +52,56 @@ pub const CAPTURE_STATE: u32 = abi::EVENT_CONTROL_CODE_CAPTURE_STATE;
 const EMPTY_PROVIDER: Guid = Guid::from_u128(0u128);
 
 /// Cumulative loss/health counters for a running ETW session.
-/// 
+///
 /// All counters are cumulative since session start and reset only when
 /// the session is stopped. Apply deltas between consecutive polls to
 /// track rate-of-loss metrics.
+///
+/// The native ETW counters are 32-bit and are widened to `u64` here for
+/// ergonomic delta math and future-proofing. Because the underlying
+/// values can wrap on long-running sessions, compute deltas using
+/// wrapping subtraction rather than assuming strict monotonicity.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 pub struct TraceStats {
+    /// Events dropped because no free buffer was available when the
+    /// provider tried to log them (widened from the native `u32`).
     pub events_lost: u64,
+    /// Real-time delivery buffers lost in transit to the consumer
+    /// (widened from the native `u32`).
     pub real_time_buffers_lost: u64,
+    /// Buffers that could not be flushed to the log file
+    /// (widened from the native `u32`).
     pub log_buffers_lost: u64,
+    /// Buffers successfully written since session start
+    /// (widened from the native `u32`).
     pub buffers_written: u64,
 }
 
 /// Query a running session's loss counters by its raw handle.
-/// 
-/// Safe to call from any thread; the handle is `Send` and the query
-/// is stateless. Returns cumulative counters since session start.
+///
+/// The `handle` must be a live ETW session handle, such as the value
+/// captured from [`SessionCallbackContext::handle`] inside an
+/// `add_started_callback` closure. Returns cumulative counters since
+/// session start.
+///
+/// # Thread safety and handle lifecycle
+///
+/// The query itself is stateless and the handle is `Send`, so this may
+/// be called from any thread while the session is running. The caller is
+/// responsible for ensuring the handle outlives the call: once the
+/// session is stopped or torn down the handle becomes stale, and querying
+/// a stale handle will fail with a Win32 error (for example, the session
+/// instance no longer being found) rather than returning stale data.
+///
+/// # Errors
+///
+/// Returns an error if `handle` is zero (the never-started sentinel) or if
+/// the underlying `ControlTraceW` query fails (for example, when the
+/// session handle is stale after teardown).
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
 /// use std::sync::Arc;
 /// use std::sync::atomic::{AtomicU64, Ordering};
 /// use one_collect::etw::{EtwSession, query_stats};
@@ -82,13 +112,14 @@ pub struct TraceStats {
 /// {
 ///     let handle_slot = handle_slot.clone();
 ///     session.add_started_callback(move |ctx| {
-///         handle_slot.store(ctx.handle(), Ordering::SeqCst);
+///         // Release-store publishes the handle to other threads.
+///         handle_slot.store(ctx.handle(), Ordering::Release);
 ///     });
 /// }
 ///
 /// // Start `parse_until` or `parse_for_duration` on your desired cadence,
 /// // then poll from any thread/task and compute deltas between polls.
-/// let handle = handle_slot.load(Ordering::SeqCst);
+/// let handle = handle_slot.load(Ordering::Acquire);
 /// if handle != 0 {
 ///     if let Ok(stats) = query_stats(handle) {
 ///         let _ = stats.events_lost;
@@ -96,6 +127,12 @@ pub struct TraceStats {
 /// }
 /// ```
 pub fn query_stats(handle: u64) -> anyhow::Result<TraceStats> {
+    if handle == 0 {
+        anyhow::bail!(
+            "query_stats called with an invalid (zero) session handle; \
+             capture a live handle from SessionCallbackContext::handle first");
+    }
+
     abi::query_stats(handle).map(|raw| TraceStats {
         events_lost: raw.events_lost as u64,
         real_time_buffers_lost: raw.real_time_buffers_lost as u64,
@@ -103,7 +140,6 @@ pub fn query_stats(handle: u64) -> anyhow::Result<TraceStats> {
         buffers_written: raw.buffers_written as u64,
     })
 }
-
 
 #[derive(Default)]
 pub struct AncillaryData {
@@ -328,10 +364,22 @@ impl SessionCallbackContext {
         }
     }
 
+    /// The raw ETW session handle for this callback's session.
+    ///
+    /// Valid for the duration of the session (from the `started`
+    /// callback until the session is stopped/torn down). Capturing this
+    /// value lets other threads poll the session via [`query_stats`];
+    /// the handle becomes stale after teardown, at which point queries
+    /// fail rather than return stale data.
     pub fn handle(&self) -> u64 { 
         self.handle
     }
 
+    /// Query the running session's loss counters.
+    ///
+    /// Convenience wrapper over [`query_stats`] using this context's
+    /// handle. Only valid while the session is running; see
+    /// [`query_stats`] for handle-lifecycle and error semantics.
     pub fn query_stats(&self) -> anyhow::Result<TraceStats> {
         query_stats(self.handle)
     }
@@ -1341,6 +1389,17 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::time::Duration;
+
+    #[test]
+    fn query_stats_rejects_zero_handle() {
+        // A zero handle is the never-started sentinel and must fail fast
+        // without crossing the ETW ABI. Deterministic, no admin/live
+        // session required, so this guards the invalid-handle contract
+        // on every CI run.
+        assert!(
+            query_stats(0).is_err(),
+            "query_stats(0) must reject the invalid (zero) handle");
+    }
 
     #[ignore]
     #[test]

--- a/one_collect/src/etw/mod.rs
+++ b/one_collect/src/etw/mod.rs
@@ -61,7 +61,7 @@ const EMPTY_PROVIDER: Guid = Guid::from_u128(0u128);
 /// sessions, so compute deltas using wrapping subtraction rather than
 /// assuming strict monotonicity.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
-pub struct TraceStats {
+pub struct SessionStats {
     /// Events dropped because no free buffer was available when the
     /// provider tried to log them.
     pub events_lost: u32,
@@ -122,7 +122,7 @@ pub struct TraceStats {
 ///     }
 /// }
 /// ```
-pub fn query_stats(handle: u64) -> anyhow::Result<TraceStats> {
+pub fn query_stats(handle: u64) -> anyhow::Result<SessionStats> {
     if handle == 0 {
         anyhow::bail!(
             "query_stats called with an invalid (zero) session handle; \

--- a/one_collect/src/etw/mod.rs
+++ b/one_collect/src/etw/mod.rs
@@ -375,15 +375,6 @@ impl SessionCallbackContext {
         self.handle
     }
 
-    /// Query the running session's loss counters.
-    ///
-    /// Convenience wrapper over [`query_stats`] using this context's
-    /// handle. Only valid while the session is running; see
-    /// [`query_stats`] for handle-lifecycle and error semantics.
-    pub fn query_stats(&self) -> anyhow::Result<TraceStats> {
-        query_stats(self.handle)
-    }
-
     pub fn id(&self) -> u64 { self.id }
 
     pub fn flush_trace(&self) {
@@ -1399,35 +1390,6 @@ mod tests {
         assert!(
             query_stats(0).is_err(),
             "query_stats(0) must reject the invalid (zero) handle");
-    }
-
-    #[ignore]
-    #[test]
-    fn query_stats_by_handle() {
-        let mut session = EtwSession::new();
-
-        let handle_slot = Arc::new(AtomicU64::new(0));
-        let query_ok = Arc::new(AtomicBool::new(false));
-
-        {
-            let handle_slot = handle_slot.clone();
-            let query_ok = query_ok.clone();
-
-            session.add_started_callback(move |ctx| {
-                handle_slot.store(ctx.handle(), Ordering::SeqCst);
-                if ctx.query_stats().is_ok() {
-                    query_ok.store(true, Ordering::SeqCst);
-                }
-            });
-        }
-
-        session
-            .parse_for_duration("one_collect_query_stats_test", Duration::from_secs(1))
-            .unwrap();
-
-        let handle = handle_slot.load(Ordering::SeqCst);
-        assert!(handle != 0, "started callback did not capture a valid session handle");
-        assert!(query_ok.load(Ordering::SeqCst), "query_stats failed while session was running");
     }
 
     #[ignore]

--- a/one_collect/src/etw/mod.rs
+++ b/one_collect/src/etw/mod.rs
@@ -57,24 +57,20 @@ const EMPTY_PROVIDER: Guid = Guid::from_u128(0u128);
 /// the session is stopped. Apply deltas between consecutive polls to
 /// track rate-of-loss metrics.
 ///
-/// The native ETW counters are 32-bit and are widened to `u64` here for
-/// ergonomic delta math and future-proofing. Because the underlying
-/// values can wrap on long-running sessions, compute deltas using
-/// wrapping subtraction rather than assuming strict monotonicity.
+/// The native ETW counters are 32-bit and can wrap on long-running
+/// sessions, so compute deltas using wrapping subtraction rather than
+/// assuming strict monotonicity.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 pub struct TraceStats {
     /// Events dropped because no free buffer was available when the
-    /// provider tried to log them (widened from the native `u32`).
-    pub events_lost: u64,
-    /// Real-time delivery buffers lost in transit to the consumer
-    /// (widened from the native `u32`).
-    pub real_time_buffers_lost: u64,
-    /// Buffers that could not be flushed to the log file
-    /// (widened from the native `u32`).
-    pub log_buffers_lost: u64,
-    /// Buffers successfully written since session start
-    /// (widened from the native `u32`).
-    pub buffers_written: u64,
+    /// provider tried to log them.
+    pub events_lost: u32,
+    /// Real-time delivery buffers lost in transit to the consumer.
+    pub real_time_buffers_lost: u32,
+    /// Buffers that could not be flushed to the log file.
+    pub log_buffers_lost: u32,
+    /// Buffers successfully written since session start.
+    pub buffers_written: u32,
 }
 
 /// Query a running session's loss counters by its raw handle.
@@ -133,12 +129,7 @@ pub fn query_stats(handle: u64) -> anyhow::Result<TraceStats> {
              capture a live handle from SessionCallbackContext::handle first");
     }
 
-    abi::query_stats(handle).map(|raw| TraceStats {
-        events_lost: raw.events_lost as u64,
-        real_time_buffers_lost: raw.real_time_buffers_lost as u64,
-        log_buffers_lost: raw.log_buffers_lost as u64,
-        buffers_written: raw.buffers_written as u64,
-    })
+    abi::query_stats(handle)
 }
 
 #[derive(Default)]

--- a/one_collect/src/etw/mod.rs
+++ b/one_collect/src/etw/mod.rs
@@ -51,6 +51,60 @@ pub const CAPTURE_STATE: u32 = abi::EVENT_CONTROL_CODE_CAPTURE_STATE;
 
 const EMPTY_PROVIDER: Guid = Guid::from_u128(0u128);
 
+/// Cumulative loss/health counters for a running ETW session.
+/// 
+/// All counters are cumulative since session start and reset only when
+/// the session is stopped. Apply deltas between consecutive polls to
+/// track rate-of-loss metrics.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub struct TraceStats {
+    pub events_lost: u64,
+    pub real_time_buffers_lost: u64,
+    pub log_buffers_lost: u64,
+    pub buffers_written: u64,
+}
+
+/// Query a running session's loss counters by its raw handle.
+/// 
+/// Safe to call from any thread; the handle is `Send` and the query
+/// is stateless. Returns cumulative counters since session start.
+///
+/// # Example
+///
+/// ```ignore
+/// use std::sync::Arc;
+/// use std::sync::atomic::{AtomicU64, Ordering};
+/// use one_collect::etw::{EtwSession, query_stats};
+///
+/// let mut session = EtwSession::new();
+/// let handle_slot = Arc::new(AtomicU64::new(0));
+///
+/// {
+///     let handle_slot = handle_slot.clone();
+///     session.add_started_callback(move |ctx| {
+///         handle_slot.store(ctx.handle(), Ordering::SeqCst);
+///     });
+/// }
+///
+/// // Start `parse_until` or `parse_for_duration` on your desired cadence,
+/// // then poll from any thread/task and compute deltas between polls.
+/// let handle = handle_slot.load(Ordering::SeqCst);
+/// if handle != 0 {
+///     if let Ok(stats) = query_stats(handle) {
+///         let _ = stats.events_lost;
+///     }
+/// }
+/// ```
+pub fn query_stats(handle: u64) -> anyhow::Result<TraceStats> {
+    abi::query_stats(handle).map(|raw| TraceStats {
+        events_lost: raw.events_lost as u64,
+        real_time_buffers_lost: raw.real_time_buffers_lost as u64,
+        log_buffers_lost: raw.log_buffers_lost as u64,
+        buffers_written: raw.buffers_written as u64,
+    })
+}
+
+
 #[derive(Default)]
 pub struct AncillaryData {
     event: Option<*const EVENT_RECORD>,
@@ -272,6 +326,14 @@ impl SessionCallbackContext {
             handle,
             id,
         }
+    }
+
+    pub fn handle(&self) -> u64 { 
+        self.handle
+    }
+
+    pub fn query_stats(&self) -> anyhow::Result<TraceStats> {
+        query_stats(self.handle)
     }
 
     pub fn id(&self) -> u64 { self.id }
@@ -1276,6 +1338,72 @@ impl EtwSession {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::time::Duration;
+
+    #[ignore]
+    #[test]
+    fn query_stats_by_handle() {
+        let mut session = EtwSession::new();
+
+        let handle_slot = Arc::new(AtomicU64::new(0));
+        let query_ok = Arc::new(AtomicBool::new(false));
+
+        {
+            let handle_slot = handle_slot.clone();
+            let query_ok = query_ok.clone();
+
+            session.add_started_callback(move |ctx| {
+                handle_slot.store(ctx.handle(), Ordering::SeqCst);
+                if ctx.query_stats().is_ok() {
+                    query_ok.store(true, Ordering::SeqCst);
+                }
+            });
+        }
+
+        session
+            .parse_for_duration("one_collect_query_stats_test", Duration::from_secs(1))
+            .unwrap();
+
+        let handle = handle_slot.load(Ordering::SeqCst);
+        assert!(handle != 0, "started callback did not capture a valid session handle");
+        assert!(query_ok.load(Ordering::SeqCst), "query_stats failed while session was running");
+    }
+
+    #[ignore]
+    #[test]
+    fn query_stats_free_function_with_captured_handle() {
+        let mut session = EtwSession::new();
+
+        let handle_slot = Arc::new(AtomicU64::new(0));
+        let query_ok = Arc::new(AtomicBool::new(false));
+
+        {
+            let handle_slot = handle_slot.clone();
+            let query_ok = query_ok.clone();
+
+            session.add_started_callback(move |ctx| {
+                handle_slot.store(ctx.handle(), Ordering::SeqCst);
+
+                let handle = handle_slot.load(Ordering::SeqCst);
+                if handle != 0 && super::query_stats(handle).is_ok() {
+                    query_ok.store(true, Ordering::SeqCst);
+                }
+            });
+        }
+
+        session
+            .parse_for_duration("one_collect_query_stats_free_fn_test", Duration::from_secs(1))
+            .unwrap();
+
+        let handle = handle_slot.load(Ordering::SeqCst);
+        assert!(handle != 0, "started callback did not capture a valid session handle");
+        assert!(
+            query_ok.load(Ordering::SeqCst),
+            "free function query_stats(handle) failed while session was running"
+        );
+    }
 
     #[ignore]
     #[test]


### PR DESCRIPTION
This PR adds support for querying ETW runtime session statistics from a running session. It introduces a public `TraceStats` API, exposes the session handle through `SessionCallbackContext`, and wires the implementation to ETW’s `ControlTraceW(..., QUERY)` path

https://github.com/microsoft/one-collect/issues/299