### PR TITLE
Add cargo-deny check to CI

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,31 @@
+name: Cargo Deny
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    # Installed from source to avoid taking on a third-party GitHub Action;
+    # `--locked` keeps the build reproducible.
+    - name: Install cargo-deny
+      run: cargo install cargo-deny --locked
+
+    # There is no workspace-level Cargo.toml, so each crate root is checked
+    # against the shared repo-root deny.toml.
+    - name: 'one_collect: cargo deny check'
+      run: cargo deny --manifest-path one_collect/Cargo.toml --config deny.toml check
+
+    - name: 'record-trace: cargo deny check'
+      run: cargo deny --manifest-path record-trace/Cargo.toml --config deny.toml check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Supply-chain audit (advisories, bans, licenses, sources). Platform-agnostic,
+  # so it runs once rather than per-platform.
+  cargo_deny:
+    uses: ./.github/workflows/cargo-deny.yml
+
   # Clippy lints ordered by platform (glibc, musl, windows)
   clippy_linux_glibc_x64:
     uses: ./.github/workflows/clippy.yml

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,41 @@
+# cargo-deny configuration for one-collect.
+#
+# cargo-deny audits the dependency graph for security advisories, disallowed or
+# duplicate crates, license compliance, and untrusted sources. See
+# https://embarkstudios.github.io/cargo-deny/ for the configuration reference.
+#
+# There is no workspace-level Cargo.toml, so CI runs cargo-deny once per crate
+# root (one_collect and record-trace) against this shared config.
+
+[advisories]
+# RustSec advisories (vulnerability / unsound / unmaintained) are always errors
+# in this cargo-deny version; `ignore` is the only escape hatch and is left
+# empty on purpose so that the current findings surface as failures.
+ignore = []
+
+[licenses]
+# Permissive licenses only. Dual/tri-licensed crates (e.g. `r-efi` is
+# `MIT OR Apache-2.0 OR LGPL-2.1-or-later`) resolve to one of these, so a
+# copyleft option is never selected.
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "MIT",
+    "Unicode-3.0",
+    "Zlib",
+]
+
+[bans]
+# Surface duplicate versions of the same crate as a warning.
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+# Only crates.io is trusted.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
Adds a cargo-deny check so CI audits the dependency graph for security advisories, disallowed/duplicate crates, license compliance, and untrusted sources. This PR only adds the check and its configuration; it does not change any dependencies.