### PR TITLE
Fix for issue #327

### DIFF
--- a/one_collect/src/helpers/exporting/os/linux.rs
+++ b/one_collect/src/helpers/exporting/os/linux.rs
@@ -1817,6 +1817,15 @@ impl UniversalExporterOSHooks for UniversalExporter {
             session.disable()?;
             exporter.borrow_mut().mark_end();
 
+            /* When the session is disabled very early (for example, because
+             * the memory limit is reached immediately), the environment-capture
+             * thread may spend several minutes waiting for ring-buffer space on
+             * systems with many processes or modules. Continue parsing
+             * concurrently so the writer can finish promptly. */
+            while !env_handle.is_finished() {
+                session.parse_all()?;
+            }
+
             /* Wait for the background capture to finish */
             let _ = env_handle.join();
 


### PR DESCRIPTION
Continue parsing the COMM, MMAP events from the environment capture thread so that there is enough space in ring buffer to add all the events from the system. This snippet avoids a several minute hang on systems with high number of COMM/MMAP events. More details in Issue #327